### PR TITLE
Hardware coherence

### DIFF
--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -68,6 +68,7 @@ var order = []struct {
 	{"automation", "Automation residue", sectionAutomation},
 	{"permissions", "Permission state coherence", sectionPermissions},
 	{"webrtc", "ICE gathering against its own reported state", sectionWebRTC},
+	{"canvasserial", "Two serialisations of one drawing surface", sectionCanvasSerial},
 	{"capabilities", "Reported media capabilities", sectionCapabilities},
 	{"hwdecode", "Hardware decoders against the device named", sectionHWDecode},
 	{"webgpu", "Both graphics interfaces against one device", sectionWebGPU},

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -67,6 +67,7 @@ var order = []struct {
 	{"automation", "Automation residue", sectionAutomation},
 	{"permissions", "Permission state coherence", sectionPermissions},
 	{"capabilities", "Reported media capabilities", sectionCapabilities},
+	{"hwdecode", "Hardware decoders against the device named", sectionHWDecode},
 	{"claims", "What this browser reported it could not do", sectionClaims},
 }
 

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -67,6 +67,7 @@ var order = []struct {
 	{"audio", "Audio buffer coherence", sectionAudioBuf},
 	{"automation", "Automation residue", sectionAutomation},
 	{"permissions", "Permission state coherence", sectionPermissions},
+	{"webrtc", "ICE gathering against its own reported state", sectionWebRTC},
 	{"capabilities", "Reported media capabilities", sectionCapabilities},
 	{"hwdecode", "Hardware decoders against the device named", sectionHWDecode},
 	{"webgpu", "Both graphics interfaces against one device", sectionWebGPU},

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -69,6 +69,7 @@ var order = []struct {
 	{"permissions", "Permission state coherence", sectionPermissions},
 	{"capabilities", "Reported media capabilities", sectionCapabilities},
 	{"hwdecode", "Hardware decoders against the device named", sectionHWDecode},
+	{"webgpu", "Both graphics interfaces against one device", sectionWebGPU},
 	{"claims", "What this browser reported it could not do", sectionClaims},
 }
 

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -60,6 +60,7 @@ var order = []struct {
 	{"numerics", "Numeric built-in behaviour", sectionMath},
 	{"throws", "Exception types against the specification", sectionThrows},
 	{"geometry", "Screen geometry against CSS", sectionGeometry},
+	{"viewport", "Viewport against the screen it claims", sectionViewport},
 	{"rects", "Layout and text metric identities", sectionRects},
 	{"mediapaths", "Agreement between the CSS and script paths", sectionMediaPaths},
 	{"time", "Time zone against measured offsets", sectionTime},

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -72,6 +72,7 @@ var order = []struct {
 	{"capabilities", "Reported media capabilities", sectionCapabilities},
 	{"hwdecode", "Hardware decoders against the device named", sectionHWDecode},
 	{"webgpu", "Both graphics interfaces against one device", sectionWebGPU},
+	{"engineversion", "Capabilities against the version claimed", sectionEngineVersion},
 	{"claims", "What this browser reported it could not do", sectionClaims},
 }
 

--- a/internal/scan/sec_canvasserial.go
+++ b/internal/scan/sec_canvasserial.go
@@ -1,0 +1,77 @@
+package scan
+
+func sectionCanvasSerial(r Request, _ Inputs, _ claim) Section {
+	s := Section{Determination: Unverified}
+
+	v, ok := r.value("canvas.serial")
+	if !ok {
+		s.Rows = append(s.Rows, Row{
+			Label: "conclusion",
+			Value: "not collected",
+			Note:  "this reading compares two canvas serialisation paths against each other; a payload that ran neither leaves it nothing to apply to",
+		})
+		return s
+	}
+
+	dataAvail, haveDataAvail := boolean(v, "dataUrlAvailable")
+	blobAvail, haveBlobAvail := boolean(v, "blobAvailable")
+	if !haveDataAvail || !dataAvail || !haveBlobAvail || !blobAvail {
+		s.Rows = append(s.Rows, Row{
+			Label: "canvas serialisation, both paths",
+			Value: "one or both paths unavailable",
+			Note:  "a browser that cannot serialise a canvas by one of these paths is not read as suspicious for lacking it",
+		})
+		return s
+	}
+
+	rawHash, haveRaw := str(v, "rawHash")
+	dataHash, haveDataHash := str(v, "dataUrlHash")
+	dataMatch, haveDataMatch := boolean(v, "dataUrlPixelsMatchRaw")
+	blobHash, haveBlobHash := str(v, "blobHash")
+	blobMatch, haveBlobMatch := boolean(v, "blobPixelsMatchRaw")
+
+	if !haveRaw || !haveDataHash || !haveDataMatch || !haveBlobHash || !haveBlobMatch {
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "one of the readings was not reported", Note: "nothing was compared"})
+		return s
+	}
+
+	s.Rows = append(s.Rows, Row{Label: "raw canvas pixels", Value: rawHash, Note: "a hash of the untouched canvas's own pixel buffer, read before either serialisation path ran"})
+	s.Rows = append(s.Rows, Row{Label: "toDataURL PNG, decoded pixels vs raw canvas", Value: answerOrAbsent(dataMatch, true), Note: ""})
+	s.Rows = append(s.Rows, Row{Label: "toBlob PNG, decoded pixels vs raw canvas", Value: answerOrAbsent(blobMatch, true), Note: ""})
+
+	if !dataMatch || !blobMatch {
+		s.Rows = append(s.Rows, Row{
+			Label: "conclusion",
+			Value: "one of the encoded paths did not decode back to the canvas's own pixels",
+			Note:  "the two encoders are not compared to each other while either has already drifted from the content itself; this reading has nothing to say about the encoders until the content is first established as identical",
+		})
+		return s
+	}
+
+	s.Rows = append(s.Rows, Row{Label: "toDataURL PNG bytes", Value: canvasSerialByteSummary(v, "dataUrlLength", dataHash), Note: "a hash and a length, never the encoded bytes themselves"})
+	s.Rows = append(s.Rows, Row{Label: "toBlob PNG bytes", Value: canvasSerialByteSummary(v, "blobLength", blobHash), Note: "a hash and a length, never the encoded bytes themselves"})
+
+	if dataHash == blobHash {
+		s.Rows = append(s.Rows, Row{
+			Label: "conclusion",
+			Value: "both serialisation paths encoded the identical pixels to the identical bytes",
+			Note:  "recorded, not scored: this project has not established byte-identical output as a specification requirement, only observed it on one baseline build",
+		})
+		return s
+	}
+
+	s.Rows = append(s.Rows, Row{
+		Label: "conclusion",
+		Value: "both serialisation paths encoded the identical pixels to different bytes",
+		Note:  "recorded, not scored: the specification does not require the two paths to produce identical bytes, and this project has not established the honest range of that difference across browser builds; a version difference between the two things being compared could explain it as easily as anything else",
+	})
+	return s
+}
+
+func canvasSerialByteSummary(v any, lengthKey, hash string) string {
+	length, haveLength := num(v, lengthKey)
+	if !haveLength {
+		return hash + ", length not reported"
+	}
+	return hash + ", " + itoa(length) + " bytes"
+}

--- a/internal/scan/sec_canvasserial_test.go
+++ b/internal/scan/sec_canvasserial_test.go
@@ -1,0 +1,175 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+func canvasSerialRequest(t *testing.T, body string) Request {
+	t.Helper()
+	if body == "" {
+		return Request{Probes: map[string]Probe{}}
+	}
+	return Request{Probes: map[string]Probe{
+		"canvas.serial": {Status: StatusOK, Value: []byte(body)},
+	}}
+}
+
+const canvasSerialAgree = `{"dataUrlAvailable":true,"blobAvailable":true,"rawHash":"aaaa","dataUrlHash":"bbbb","dataUrlLength":42350,"dataUrlPixelsMatchRaw":true,"blobHash":"bbbb","blobLength":42350,"blobPixelsMatchRaw":true}`
+
+const canvasSerialDiverge = `{"dataUrlAvailable":true,"blobAvailable":true,"rawHash":"aaaa","dataUrlHash":"bbbb","dataUrlLength":54113,"dataUrlPixelsMatchRaw":true,"blobHash":"cccc","blobLength":31150,"blobPixelsMatchRaw":true}`
+
+const canvasSerialPixelMismatch = `{"dataUrlAvailable":true,"blobAvailable":true,"rawHash":"aaaa","dataUrlHash":"bbbb","dataUrlLength":54113,"dataUrlPixelsMatchRaw":false,"blobHash":"cccc","blobLength":31150,"blobPixelsMatchRaw":true}`
+
+const canvasSerialBlobUnavailable = `{"dataUrlAvailable":true,"blobAvailable":false,"rawHash":"aaaa","dataUrlHash":"bbbb","dataUrlLength":54113,"dataUrlPixelsMatchRaw":true}`
+
+func TestCanvasSerialAlwaysReturnsUnverified(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"not collected", ""},
+		{"agreement", canvasSerialAgree},
+		{"divergence", canvasSerialDiverge},
+		{"pixel mismatch", canvasSerialPixelMismatch},
+		{"blob unavailable", canvasSerialBlobUnavailable},
+	}
+	for _, c := range cases {
+		got := sectionCanvasSerial(canvasSerialRequest(t, c.body), Inputs{}, claim{})
+		if got.Determination != Unverified {
+			t.Errorf("%s: determination = %q, want %q: this reading has not established a normative baseline across builds and must never score", c.name, got.Determination, Unverified)
+		}
+	}
+}
+
+func TestCanvasSerialDoesNotMoveTheScoreOnAnyInputShape(t *testing.T) {
+	base := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Inconclusive},
+	}
+	before := summarise(base)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"agreement", canvasSerialAgree},
+		{"divergence", canvasSerialDiverge},
+		{"missing data", ""},
+		{"pixels differ from raw", canvasSerialPixelMismatch},
+	}
+	for _, c := range cases {
+		sec := sectionCanvasSerial(canvasSerialRequest(t, c.body), Inputs{}, claim{})
+		sec.ID = "canvasserial"
+		after := summarise(append(append([]Section{}, base...), normalise(sec)))
+		if before.Band != after.Band {
+			t.Errorf("%s: band moved from %q to %q merely by adding this reading", c.name, before.Band, after.Band)
+		}
+		if before.HumanConfidence != after.HumanConfidence {
+			t.Errorf("%s: human confidence moved from %d to %d", c.name, before.HumanConfidence, after.HumanConfidence)
+		}
+		if before.BotLikeness != after.BotLikeness {
+			t.Errorf("%s: bot likeness moved from %d to %d", c.name, before.BotLikeness, after.BotLikeness)
+		}
+	}
+}
+
+func canvasSerialWrongSection(r Request, in Inputs, c claim) Section {
+	sec := sectionCanvasSerial(r, in, c)
+	for _, row := range sec.Rows {
+		if row.Label == "conclusion" && strings.Contains(row.Value, "different bytes") {
+			sec.Determination = Contradiction
+		}
+	}
+	return sec
+}
+
+func TestCanvasSerialMovementTestHasTeeth(t *testing.T) {
+	base := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Inconclusive},
+	}
+	before := summarise(base)
+
+	wrong := canvasSerialWrongSection(canvasSerialRequest(t, canvasSerialDiverge), Inputs{}, claim{})
+	wrong.ID = "canvasserial"
+	after := summarise(append(append([]Section{}, base...), normalise(wrong)))
+
+	if before.Band == after.Band && before.HumanConfidence == after.HumanConfidence && before.BotLikeness == after.BotLikeness {
+		t.Fatal("a deliberately wrong section that scores divergence as a contradiction left the summary unchanged; the movement test above would not have caught a scoring reading, so it has no teeth")
+	}
+}
+
+func TestCanvasSerialNamesNoVendorInItsConclusion(t *testing.T) {
+	got := sectionCanvasSerial(canvasSerialRequest(t, canvasSerialDiverge), Inputs{}, claim{})
+	for _, row := range got.Rows {
+		if row.Label != "conclusion" {
+			continue
+		}
+		for _, forbidden := range []string{"Chrome", "Chromium", "NVIDIA"} {
+			if strings.Contains(row.Value+" "+row.Note, forbidden) {
+				t.Errorf("the conclusion names %q: %q / %q", forbidden, row.Value, row.Note)
+			}
+		}
+	}
+}
+
+func TestCanvasSerialAbstainsWhenBlobIsUnavailable(t *testing.T) {
+	got := sectionCanvasSerial(canvasSerialRequest(t, canvasSerialBlobUnavailable), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q", got.Determination, Unverified)
+	}
+	found := false
+	for _, row := range got.Rows {
+		if strings.Contains(row.Value, "unavailable") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a row noting one of the paths was unavailable")
+	}
+}
+
+func TestCanvasSerialAbstainsWhenDecodedPixelsDoNotMatchRaw(t *testing.T) {
+	got := sectionCanvasSerial(canvasSerialRequest(t, canvasSerialPixelMismatch), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q", got.Determination, Unverified)
+	}
+	for _, row := range got.Rows {
+		if row.Label == "conclusion" && !strings.Contains(row.Value, "did not decode back") {
+			t.Errorf("conclusion did not mention the pixel mismatch: %q", row.Value)
+		}
+	}
+}
+
+func TestCanvasSerialRecordsAgreementAndDivergenceDifferently(t *testing.T) {
+	agree := sectionCanvasSerial(canvasSerialRequest(t, canvasSerialAgree), Inputs{}, claim{})
+	diverge := sectionCanvasSerial(canvasSerialRequest(t, canvasSerialDiverge), Inputs{}, claim{})
+
+	if agree.Determination != Unverified || diverge.Determination != Unverified {
+		t.Fatal("both shapes must remain unverified")
+	}
+
+	agreeConclusion, divergeConclusion := "", ""
+	for _, row := range agree.Rows {
+		if row.Label == "conclusion" {
+			agreeConclusion = row.Value
+		}
+	}
+	for _, row := range diverge.Rows {
+		if row.Label == "conclusion" {
+			divergeConclusion = row.Value
+		}
+	}
+	if agreeConclusion == divergeConclusion {
+		t.Error("agreement and divergence produced the same conclusion text; the reading is not recording what it saw")
+	}
+	if !strings.Contains(agreeConclusion, "identical bytes") {
+		t.Errorf("agreement conclusion = %q", agreeConclusion)
+	}
+	if !strings.Contains(divergeConclusion, "different bytes") {
+		t.Errorf("divergence conclusion = %q", divergeConclusion)
+	}
+}

--- a/internal/scan/sec_engineversion.go
+++ b/internal/scan/sec_engineversion.go
@@ -1,0 +1,94 @@
+package scan
+
+import (
+	"regexp"
+	"strconv"
+
+	"github.com/N4darae/anti-mage/reference"
+)
+
+var chromeMajorPattern = regexp.MustCompile(`Chrome/([0-9]+)`)
+
+func claimedEngineMajor(c claim) (int, bool) {
+	m := chromeMajorPattern.FindStringSubmatch(c.UserAgent)
+	if m == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func sectionEngineVersion(r Request, _ Inputs, c claim) Section {
+	s := Section{Determination: Unverified}
+
+	claimed, ok := claimedEngineMajor(c)
+	if !ok {
+		s.Rows = append(s.Rows, Row{
+			Label: "engine version, as claimed",
+			Value: "not reported",
+			Note:  "this reading compares an engine's reported capabilities against the version it claims; without a parseable version there is nothing to compare them to",
+		})
+		return s
+	}
+	s.Rows = append(s.Rows, Row{Label: "engine version, as claimed", Value: strconv.Itoa(claimed), Note: "the major version this environment reports for itself"})
+
+	features, ok := r.value("engine.features")
+	if !ok {
+		s.Rows = append(s.Rows, Row{Label: "engine feature observations", Value: "not collected", Note: "no capability answers were reported, so nothing was compared"})
+		return s
+	}
+
+	applicable := 0
+	laterPresent := []Row{}
+	for _, fe := range reference.EngineFeatures {
+		if !fe.Verified {
+			continue
+		}
+		if fe.ShipsInMajor <= claimed {
+			continue
+		}
+		present, known := boolean(features, fe.ID)
+		if !known {
+			continue
+		}
+		applicable++
+		if present {
+			laterPresent = append(laterPresent, Row{
+				Label: fe.Description,
+				Value: "present",
+				Note:  "tabulated as shipping at major " + strconv.Itoa(fe.ShipsInMajor) + ", which is later than the version this environment claims; source: " + clip(fe.Source.Origin, 120),
+			})
+		}
+	}
+
+	if applicable == 0 {
+		s.Rows = append(s.Rows, Row{
+			Label: "conclusion",
+			Value: "no tabulated, verified capability ships after the version this environment claims",
+			Note:  "either the claimed version already covers everything this table has confirmed on a real system, or none of the tabulated capabilities were reported, so this reading has nothing to apply to this payload",
+		})
+		return s
+	}
+
+	if len(laterPresent) > 0 {
+		s.Determination = Contradiction
+		s.Rows = append(s.Rows, laterPresent...)
+		s.Rows = append(s.Rows, Row{
+			Label: "conclusion",
+			Value: "this environment demonstrates a capability tabulated as shipping later than the version it claims",
+			Note:  "a genuine engine cannot run a capability that its own claimed version predates; the claim and the capability cannot both describe one engine",
+		})
+		return s
+	}
+
+	s.Determination = Consistent
+	s.Rows = append(s.Rows, Row{
+		Label: "conclusion",
+		Value: "no capability later than the claimed version was demonstrated",
+		Note:  "",
+	})
+	return s
+}

--- a/internal/scan/sec_engineversion_test.go
+++ b/internal/scan/sec_engineversion_test.go
@@ -1,0 +1,88 @@
+package scan
+
+import "testing"
+
+const engine149UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
+const engine151UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36"
+
+func engineFeaturesRequest(t *testing.T, features string) Request {
+	t.Helper()
+	r := Request{Probes: map[string]Probe{}}
+	if features != "" {
+		r.Probes["engine.features"] = Probe{Status: StatusOK, Value: []byte(features)}
+	}
+	return r
+}
+
+func TestEngineVersionAbstainsWhenNoVersionCanBeParsed(t *testing.T) {
+	got := sectionEngineVersion(engineFeaturesRequest(t, `{"rubyOverhang":false}`), Inputs{}, claim{UserAgent: "some browser, no version here"})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: a claim with no parseable version leaves this reading nothing to compare", got.Determination, Unverified)
+	}
+}
+
+func TestEngineVersionAbstainsWhenNoFeaturesWereCollected(t *testing.T) {
+	got := sectionEngineVersion(Request{Probes: map[string]Probe{}}, Inputs{}, claim{UserAgent: engine149UA})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q", got.Determination, Unverified)
+	}
+}
+
+func TestEngineVersionAbstainsWhenClaimAlreadyCoversEveryVerifiedFeature(t *testing.T) {
+	got := sectionEngineVersion(engineFeaturesRequest(t, `{"rubyOverhang":true,"animationEventAnimation":true,"transitionEventAnimation":true,"userMediaElement":true,"softNavigations":true}`), Inputs{}, claim{UserAgent: engine151UA})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: a claimed version at or beyond every verified row leaves nothing later to test", got.Determination, Unverified)
+	}
+}
+
+func TestEngineVersionIsConsistentWhenNoLaterCapabilityIsPresent(t *testing.T) {
+	got := sectionEngineVersion(engineFeaturesRequest(t, `{"rubyOverhang":false,"animationEventAnimation":false,"transitionEventAnimation":false,"userMediaElement":false,"softNavigations":false}`), Inputs{}, claim{UserAgent: engine149UA})
+	if got.Determination != Consistent {
+		t.Fatalf("determination = %q, want %q: this is exactly what the paladin session in this round reported, and its engine genuinely was 149", got.Determination, Consistent)
+	}
+}
+
+func TestEngineVersionIsContradictionWhenALaterCapabilityIsPresent(t *testing.T) {
+	got := sectionEngineVersion(engineFeaturesRequest(t, `{"rubyOverhang":true,"animationEventAnimation":false,"transitionEventAnimation":false,"userMediaElement":false,"softNavigations":false}`), Inputs{}, claim{UserAgent: engine149UA})
+	if got.Determination != Contradiction {
+		t.Fatalf("determination = %q, want %q: a capability tabulated as shipping at 151 cannot exist in a genuine 149 engine", got.Determination, Contradiction)
+	}
+}
+
+func TestEngineVersionDoesNotScoreAMissingCapabilityAsEvidence(t *testing.T) {
+	got := sectionEngineVersion(engineFeaturesRequest(t, `{}`), Inputs{}, claim{UserAgent: engine149UA})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: with no feature keys reported, no row is applicable, and absence must never be scored", got.Determination, Unverified)
+	}
+}
+
+func TestEngineVersionIgnoresUnverifiedRows(t *testing.T) {
+
+	got := sectionEngineVersion(engineFeaturesRequest(t, `{"textFit":true,"bgClipBorderArea":true}`), Inputs{}, claim{UserAgent: engine149UA})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: textFit and bgClipBorderArea are tabulated but not Verified, so their presence must not drive a verdict", got.Determination, Unverified)
+	}
+}
+
+func TestEngineVersionDoesNotDiluteAPayloadThatPredatesIt(t *testing.T) {
+	sections := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Inconclusive},
+	}
+	before := summarise(sections)
+
+	absent := sectionEngineVersion(Request{Probes: map[string]Probe{}}, Inputs{}, claim{})
+	absent.ID = "engineversion"
+	after := summarise(append(sections, normalise(absent)))
+
+	if before.Band != after.Band {
+		t.Errorf("band moved from %q to %q merely by adding a reading the payload has no data for", before.Band, after.Band)
+	}
+	if before.HumanConfidence != after.HumanConfidence {
+		t.Errorf("human confidence moved from %d to %d", before.HumanConfidence, after.HumanConfidence)
+	}
+	if before.BotLikeness != after.BotLikeness {
+		t.Errorf("bot likeness moved from %d to %d", before.BotLikeness, after.BotLikeness)
+	}
+}

--- a/internal/scan/sec_hwdecode.go
+++ b/internal/scan/sec_hwdecode.go
@@ -14,11 +14,10 @@ const (
 var geForceRTXModel = regexp.MustCompile(`GeForce RTX ([0-9]{4})`)
 
 func sectionHWDecode(r Request, _ Inputs, _ claim) Section {
-	s := Section{Determination: Inconclusive}
+	s := Section{Determination: Unverified}
 
 	renderer, ok := hwDecodeRenderer(r)
 	if !ok {
-		s.Determination = Unverified
 		s.Rows = append(s.Rows, Row{
 			Label: "graphics device, as reported",
 			Value: "not collected",
@@ -30,14 +29,12 @@ func sectionHWDecode(r Request, _ Inputs, _ claim) Section {
 
 	series, entry, placed := hwDecodeEntry(renderer)
 	if !placed {
-		s.Determination = Unverified
 		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "this project's table does not place the reported device", Note: "no decoder capability follows from a device this project has not tabulated, so this reading carries no weight for it"})
 		return s
 	}
 	s.Rows = append(s.Rows, Row{Label: "device generation", Value: entry.Family, Note: "read from the " + series + " series in this project's table"})
 
 	if !entry.Verified {
-		s.Determination = Unverified
 		s.Rows = append(s.Rows, Row{
 			Label: "conclusion",
 			Value: "the table entry for this generation has not been confirmed on a real system of that configuration",

--- a/internal/scan/sec_hwdecode.go
+++ b/internal/scan/sec_hwdecode.go
@@ -1,0 +1,128 @@
+package scan
+
+import (
+	"regexp"
+
+	"github.com/N4darae/anti-mage/reference"
+)
+
+const (
+	hwDecodeControl = "H.264 high, MP4"
+	hwDecodeSubject = "AV1, WebM"
+)
+
+var geForceRTXModel = regexp.MustCompile(`GeForce RTX ([0-9]{4})`)
+
+func sectionHWDecode(r Request, _ Inputs, _ claim) Section {
+	s := Section{Determination: Inconclusive}
+
+	renderer, ok := hwDecodeRenderer(r)
+	if !ok {
+		s.Determination = Unverified
+		s.Rows = append(s.Rows, Row{
+			Label: "graphics device, as reported",
+			Value: "not collected",
+			Note:  "this reading compares a tabulated device against the decoders reported for it; a payload that names no device leaves it nothing to apply to, so it carries no weight either way",
+		})
+		return s
+	}
+	s.Rows = append(s.Rows, Row{Label: "graphics device, as reported", Value: clip(renderer, 90), Note: "the unmasked renderer string, which names the device this environment claims"})
+
+	series, entry, placed := hwDecodeEntry(renderer)
+	if !placed {
+		s.Determination = Unverified
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "this project's table does not place the reported device", Note: "no decoder capability follows from a device this project has not tabulated, so this reading carries no weight for it"})
+		return s
+	}
+	s.Rows = append(s.Rows, Row{Label: "device generation", Value: entry.Family, Note: "read from the " + series + " series in this project's table"})
+
+	if !entry.Verified {
+		s.Determination = Unverified
+		s.Rows = append(s.Rows, Row{
+			Label: "conclusion",
+			Value: "the table entry for this generation has not been confirmed on a real system of that configuration",
+			Note:  "its documented capability is not read as evidence until it has been observed; source: " + clip(entry.Source.Origin, 120),
+		})
+		return s
+	}
+
+	matrix, ok := r.value("media.matrix")
+	if !ok {
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "the media capability matrix was not collected", Note: "nothing was compared"})
+		return s
+	}
+
+	controlEfficient, haveControl := boolean(matrix, hwDecodeControl, "powerEfficient")
+	subjectSupported, haveSupport := boolean(matrix, hwDecodeSubject, "decodingInfoSupported")
+	subjectEfficient, haveSubject := boolean(matrix, hwDecodeSubject, "powerEfficient")
+
+	s.Rows = append(s.Rows, Row{Label: "a widely implemented codec, decoded in hardware", Value: answerOrAbsent(controlEfficient, haveControl), Note: "the control: it shows whether this environment has a working hardware decoder at all"})
+	s.Rows = append(s.Rows, Row{Label: "the tabulated codec, decodable", Value: answerOrAbsent(subjectSupported, haveSupport), Note: "whether this build can decode it by any path"})
+	s.Rows = append(s.Rows, Row{Label: "the tabulated codec, decoded in hardware", Value: answerOrAbsent(subjectEfficient, haveSubject), Note: "the reading this generation's tabulated decoder is compared against"})
+
+	if !haveControl || !haveSupport || !haveSubject {
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "one of the three readings was not reported", Note: "nothing was compared"})
+		return s
+	}
+	if !controlEfficient {
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "no codec was decoded in hardware here", Note: "an environment with no working hardware decoder cannot be read as missing one decoder in particular"})
+		return s
+	}
+	if !subjectSupported {
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "this build cannot decode the tabulated codec at all", Note: "a codec a build does not carry is a fact about the build, never a mark against it"})
+		return s
+	}
+	if !entry.AV1Decode {
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "this generation is not tabulated as carrying the decoder", Note: "there is nothing for the reported answer to contradict"})
+		return s
+	}
+	if !subjectEfficient {
+		s.Determination = Contradiction
+		s.Rows = append(s.Rows, Row{
+			Label: "conclusion",
+			Value: "this environment decodes one codec in hardware and reports no hardware decoder for another that the generation it names carries",
+			Note:  "the device named, the working hardware decoder, and the missing one cannot all describe one machine",
+		})
+		return s
+	}
+
+	s.Determination = Consistent
+	s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "the decoders reported are the ones the generation this device names carries", Note: ""})
+	return s
+}
+
+func hwDecodeRenderer(r Request) (string, bool) {
+	raw, ok := r.value("gpu.renderer")
+	if !ok {
+		return "", false
+	}
+	for _, key := range []string{"unmaskedRenderer", "renderer"} {
+		if s, ok := str(raw, key); ok && s != "" {
+			return s, true
+		}
+	}
+	return "", false
+}
+
+func hwDecodeEntry(renderer string) (string, reference.GPUDecode, bool) {
+	m := geForceRTXModel.FindStringSubmatch(renderer)
+	if m == nil {
+		return "", reference.GPUDecode{}, false
+	}
+	series := m[1][:2]
+	entry, ok := reference.NvidiaGeForceDecode[series]
+	if !ok {
+		return series, reference.GPUDecode{}, false
+	}
+	return series, entry, true
+}
+
+func answerOrAbsent(value, present bool) string {
+	if !present {
+		return "not reported"
+	}
+	if value {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/scan/sec_hwdecode_test.go
+++ b/internal/scan/sec_hwdecode_test.go
@@ -1,0 +1,187 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+func hwDecodeRequest(t *testing.T, renderer string, controlEfficient, av1Efficient any, av1Supported any) Request {
+	t.Helper()
+	r := Request{Probes: map[string]Probe{}}
+	if renderer != "" {
+		r.Probes["gpu.renderer"] = Probe{
+			Status: StatusOK,
+			Value:  []byte(`{"unmaskedRenderer":"` + renderer + `"}`),
+		}
+	}
+	matrix := `{"H.264 high, MP4":{"contentType":"video/mp4","decodingInfoSupported":true,"powerEfficient":` +
+		jsonBool(controlEfficient) + `},` +
+		`"AV1, WebM":{"contentType":"video/webm","decodingInfoSupported":` + jsonBool(av1Supported) +
+		`,"powerEfficient":` + jsonBool(av1Efficient) + `}}`
+	r.Probes["media.matrix"] = Probe{Status: StatusOK, Value: []byte(matrix)}
+	return r
+}
+
+func jsonBool(v any) string {
+	switch v {
+	case true:
+		return "true"
+	case false:
+		return "false"
+	}
+	return "null"
+}
+
+const ampereRenderer = "ANGLE (NVIDIA, NVIDIA GeForce RTX 3060 Ti (0x00002489) Direct3D11 vs_5_0 ps_5_0, D3D11)"
+const adaRenderer = "ANGLE (NVIDIA, NVIDIA GeForce RTX 4070 Ti (0x00002782) Direct3D11 vs_5_0 ps_5_0, D3D11)"
+
+func TestHWDecodeCarriesNoWeightWhenNoRendererWasCollected(t *testing.T) {
+	got := sectionHWDecode(hwDecodeRequest(t, "", true, false, true), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: a payload that names no device leaves this reading nothing to apply to, and it must not enter the count", got.Determination, Unverified)
+	}
+}
+
+func TestHWDecodeDoesNotDiluteAPayloadThatPredatesIt(t *testing.T) {
+	sections := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Inconclusive},
+	}
+	before := summarise(sections)
+
+	absent := sectionHWDecode(Request{Probes: map[string]Probe{}}, Inputs{}, claim{})
+	absent.ID = "hwdecode"
+	after := summarise(append(sections, normalise(absent)))
+
+	if before.Band != after.Band {
+		t.Errorf("band moved from %q to %q merely by adding a reading the payload has no data for", before.Band, after.Band)
+	}
+	if before.HumanConfidence != after.HumanConfidence {
+		t.Errorf("human confidence moved from %d to %d", before.HumanConfidence, after.HumanConfidence)
+	}
+}
+
+func TestHWDecodeCarriesNoWeightOnARendererItCannotPlace(t *testing.T) {
+	for _, renderer := range []string{
+		"ANGLE (Intel, Intel(R) UHD Graphics 620 Direct3D11 vs_5_0 ps_5_0, D3D11)",
+		"ANGLE (AMD, AMD Radeon RX 6800 XT Direct3D11 vs_5_0 ps_5_0, D3D11)",
+		"Apple GPU",
+		"ANGLE (NVIDIA, NVIDIA GeForce GTX 1080 Direct3D11 vs_5_0 ps_5_0, D3D11)",
+		"ANGLE (NVIDIA, NVIDIA Quadro P2000 Direct3D11 vs_5_0 ps_5_0, D3D11)",
+	} {
+		got := sectionHWDecode(hwDecodeRequest(t, renderer, true, false, true), Inputs{}, claim{})
+		if got.Determination != Unverified {
+			t.Errorf("renderer %q: determination = %q, want %q: a device outside this project's table leaves the reading nothing to apply", renderer, got.Determination, Unverified)
+		}
+	}
+}
+
+func TestHWDecodeYieldsUnverifiedForAGenerationNotObservedOnRealHardware(t *testing.T) {
+	got := sectionHWDecode(hwDecodeRequest(t, adaRenderer, true, false, true), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: the 40 series table entry is not verified", got.Determination, Unverified)
+	}
+}
+
+func TestHWDecodeReportsContradictionWhenAVerifiedGenerationLacksItsOwnDecoder(t *testing.T) {
+	got := sectionHWDecode(hwDecodeRequest(t, ampereRenderer, true, false, true), Inputs{}, claim{})
+	if got.Determination != Contradiction {
+		t.Fatalf("determination = %q, want %q", got.Determination, Contradiction)
+	}
+}
+
+func TestHWDecodeNamesNoVendorInItsConclusion(t *testing.T) {
+	got := sectionHWDecode(hwDecodeRequest(t, ampereRenderer, true, false, true), Inputs{}, claim{})
+	for _, row := range got.Rows {
+		if row.Label != "conclusion" {
+			continue
+		}
+		for _, forbidden := range []string{"NVIDIA", "GeForce", "RTX", "3060"} {
+			if strings.Contains(row.Value+" "+row.Note, forbidden) {
+				t.Errorf("the conclusion names %q: %q / %q", forbidden, row.Value, row.Note)
+			}
+		}
+	}
+}
+
+func TestHWDecodeAgreesWhenTheDecoderIsReportedAsPresent(t *testing.T) {
+	got := sectionHWDecode(hwDecodeRequest(t, ampereRenderer, true, true, true), Inputs{}, claim{})
+	if got.Determination != Consistent {
+		t.Fatalf("determination = %q, want %q", got.Determination, Consistent)
+	}
+}
+
+func TestHWDecodeAbstainsWhenNoHardwareDecoderWasDemonstrated(t *testing.T) {
+	got := sectionHWDecode(hwDecodeRequest(t, ampereRenderer, false, false, true), Inputs{}, claim{})
+	if got.Determination != Inconclusive {
+		t.Fatalf("determination = %q, want %q: without a control codec decoded in hardware, nothing was shown to be missing", got.Determination, Inconclusive)
+	}
+}
+
+func TestHWDecodeAbstainsWhenTheCodecIsNotSupportedAtAll(t *testing.T) {
+	got := sectionHWDecode(hwDecodeRequest(t, ampereRenderer, true, false, false), Inputs{}, claim{})
+	if got.Determination != Inconclusive {
+		t.Fatalf("determination = %q, want %q: a codec this build cannot decode at all is an absence", got.Determination, Inconclusive)
+	}
+}
+
+func TestHWDecodeAbstainsWhenAnAnswerIsMissing(t *testing.T) {
+	cases := []struct {
+		name                    string
+		control, av1, supported any
+	}{
+		{"no control answer", nil, false, true},
+		{"no codec answer", true, nil, true},
+		{"no support answer", true, false, nil},
+	}
+	for _, c := range cases {
+		got := sectionHWDecode(hwDecodeRequest(t, ampereRenderer, c.control, c.av1, c.supported), Inputs{}, claim{})
+		if got.Determination != Inconclusive {
+			t.Errorf("%s: determination = %q, want %q", c.name, got.Determination, Inconclusive)
+		}
+	}
+}
+
+func TestHWDecodeAbstainsWhenTheMatrixWasNotCollected(t *testing.T) {
+	r := Request{Probes: map[string]Probe{
+		"gpu.renderer": {Status: StatusOK, Value: []byte(`{"unmaskedRenderer":"` + ampereRenderer + `"}`)},
+	}}
+	got := sectionHWDecode(r, Inputs{}, claim{})
+	if got.Determination != Inconclusive {
+		t.Fatalf("determination = %q, want %q", got.Determination, Inconclusive)
+	}
+}
+
+func TestHWDecodeIsOneOfTheSectionsAnalyzeBuilds(t *testing.T) {
+	found := false
+	for _, s := range order {
+		if s.id == "hwdecode" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("the reading is not registered in the section order, so no scan runs it")
+	}
+}
+
+func TestAnUnverifiedSectionDoesNotMoveTheScore(t *testing.T) {
+	withoutReading := summarise([]Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+	})
+	withUnverified := summarise([]Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "hwdecode", Determination: Unverified},
+	})
+	if withoutReading.BotLikeness != withUnverified.BotLikeness {
+		t.Errorf("bot likeness moved from %d to %d", withoutReading.BotLikeness, withUnverified.BotLikeness)
+	}
+	if withoutReading.HumanConfidence != withUnverified.HumanConfidence {
+		t.Errorf("human confidence moved from %d to %d", withoutReading.HumanConfidence, withUnverified.HumanConfidence)
+	}
+	if withoutReading.Band != withUnverified.Band {
+		t.Errorf("band moved from %q to %q", withoutReading.Band, withUnverified.Band)
+	}
+}

--- a/internal/scan/sec_hwdecode_test.go
+++ b/internal/scan/sec_hwdecode_test.go
@@ -112,21 +112,21 @@ func TestHWDecodeAgreesWhenTheDecoderIsReportedAsPresent(t *testing.T) {
 	}
 }
 
-func TestHWDecodeAbstainsWhenNoHardwareDecoderWasDemonstrated(t *testing.T) {
+func TestHWDecodeCarriesNoWeightWhenNoHardwareDecoderWasDemonstrated(t *testing.T) {
 	got := sectionHWDecode(hwDecodeRequest(t, ampereRenderer, false, false, true), Inputs{}, claim{})
-	if got.Determination != Inconclusive {
-		t.Fatalf("determination = %q, want %q: without a control codec decoded in hardware, nothing was shown to be missing", got.Determination, Inconclusive)
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: without a control codec decoded in hardware, nothing was shown to be missing", got.Determination, Unverified)
 	}
 }
 
-func TestHWDecodeAbstainsWhenTheCodecIsNotSupportedAtAll(t *testing.T) {
+func TestHWDecodeCarriesNoWeightWhenTheCodecIsNotSupportedAtAll(t *testing.T) {
 	got := sectionHWDecode(hwDecodeRequest(t, ampereRenderer, true, false, false), Inputs{}, claim{})
-	if got.Determination != Inconclusive {
-		t.Fatalf("determination = %q, want %q: a codec this build cannot decode at all is an absence", got.Determination, Inconclusive)
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: a codec this build cannot decode at all is an absence", got.Determination, Unverified)
 	}
 }
 
-func TestHWDecodeAbstainsWhenAnAnswerIsMissing(t *testing.T) {
+func TestHWDecodeCarriesNoWeightWhenAnAnswerIsMissing(t *testing.T) {
 	cases := []struct {
 		name                    string
 		control, av1, supported any
@@ -137,19 +137,19 @@ func TestHWDecodeAbstainsWhenAnAnswerIsMissing(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := sectionHWDecode(hwDecodeRequest(t, ampereRenderer, c.control, c.av1, c.supported), Inputs{}, claim{})
-		if got.Determination != Inconclusive {
-			t.Errorf("%s: determination = %q, want %q", c.name, got.Determination, Inconclusive)
+		if got.Determination != Unverified {
+			t.Errorf("%s: determination = %q, want %q", c.name, got.Determination, Unverified)
 		}
 	}
 }
 
-func TestHWDecodeAbstainsWhenTheMatrixWasNotCollected(t *testing.T) {
+func TestHWDecodeCarriesNoWeightWhenTheMatrixWasNotCollected(t *testing.T) {
 	r := Request{Probes: map[string]Probe{
 		"gpu.renderer": {Status: StatusOK, Value: []byte(`{"unmaskedRenderer":"` + ampereRenderer + `"}`)},
 	}}
 	got := sectionHWDecode(r, Inputs{}, claim{})
-	if got.Determination != Inconclusive {
-		t.Fatalf("determination = %q, want %q", got.Determination, Inconclusive)
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q", got.Determination, Unverified)
 	}
 }
 
@@ -183,5 +183,43 @@ func TestAnUnverifiedSectionDoesNotMoveTheScore(t *testing.T) {
 	}
 	if withoutReading.Band != withUnverified.Band {
 		t.Errorf("band moved from %q to %q", withoutReading.Band, withUnverified.Band)
+	}
+}
+
+func TestHWDecodeCarriesNoWeightOnEveryPathThatSettlesNothing(t *testing.T) {
+	cases := []struct {
+		name string
+		req  Request
+	}{
+		{"no renderer", hwDecodeRequest(t, "", true, false, true)},
+		{"renderer this project cannot place", hwDecodeRequest(t, "ANGLE (Intel, Intel(R) UHD Graphics 620 Direct3D11 vs_5_0 ps_5_0, D3D11)", true, false, true)},
+		{"generation not observed on real hardware", hwDecodeRequest(t, adaRenderer, true, false, true)},
+		{"no control answer", hwDecodeRequest(t, ampereRenderer, nil, false, true)},
+		{"no codec answer", hwDecodeRequest(t, ampereRenderer, true, nil, true)},
+		{"no support answer", hwDecodeRequest(t, ampereRenderer, true, false, nil)},
+		{"no hardware decoder demonstrated", hwDecodeRequest(t, ampereRenderer, false, false, true)},
+		{"codec this build cannot decode at all", hwDecodeRequest(t, ampereRenderer, true, false, false)},
+		{"matrix not collected", Request{Probes: map[string]Probe{
+			"gpu.renderer": {Status: StatusOK, Value: []byte(`{"unmaskedRenderer":"` + ampereRenderer + `"}`)},
+		}}},
+	}
+
+	settled := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Inconclusive},
+	}
+	before := summarise(settled)
+
+	for _, c := range cases {
+		got := sectionHWDecode(c.req, Inputs{}, claim{})
+		if got.Determination != Unverified {
+			t.Errorf("%s: determination = %q, want %q", c.name, got.Determination, Unverified)
+		}
+		got.ID = "hwdecode"
+		after := summarise(append(settled, normalise(got)))
+		if after.Band != before.Band || after.HumanConfidence != before.HumanConfidence || after.BotLikeness != before.BotLikeness {
+			t.Errorf("%s: the summary moved from %+v to %+v", c.name, before, after)
+		}
 	}
 }

--- a/internal/scan/sec_natives_test.go
+++ b/internal/scan/sec_natives_test.go
@@ -1,0 +1,142 @@
+package scan
+
+import "testing"
+
+var domChainNativeMembers = []struct {
+	id     string
+	name   string
+	getter bool
+}{
+	{"navigator.platform", "platform", true},
+	{"screen.width", "width", true},
+	{"Node.prototype.nodeType", "nodeType", true},
+	{"Node.prototype.textContent", "textContent", true},
+	{"Element.prototype.tagName", "tagName", true},
+	{"Element.prototype.getAttribute", "getAttribute", false},
+	{"EventTarget.prototype.addEventListener", "addEventListener", false},
+	{"HTMLElement.prototype.click", "click", false},
+	{"Document.prototype.createElement", "createElement", false},
+}
+
+func honestNativePayload(members []struct {
+	id     string
+	name   string
+	getter bool
+}) map[string]string {
+	tostring, ownkeys, descriptor, receiver := "{", "{", "{", "{"
+	for i, m := range members {
+		if i > 0 {
+			tostring += ","
+			ownkeys += ","
+			descriptor += ","
+			receiver += ","
+		}
+		form := "function " + m.name + "() { [native code] }"
+		if m.getter {
+			form = "function get " + m.name + "() { [native code] }"
+		}
+		tostring += `"` + m.id + `":"` + form + `"`
+		ownkeys += `"` + m.id + `":{"ownKeys":["length","name"],"getOwnPropertyNames":["length","name"],"descriptors":["length","name"]}`
+		descriptor += `"` + m.id + `":{"onPrototype":true}`
+		receiver += `"` + m.id + `":{"threw":true,"name":"TypeError"}`
+	}
+	tostring += "}"
+	ownkeys += "}"
+	descriptor += "}"
+	receiver += "}"
+	return map[string]string{
+		"native.tostring":   ok(tostring),
+		"native.ownkeys":    ok(ownkeys),
+		"native.descriptor": ok(descriptor),
+		"native.receiver":   ok(receiver),
+	}
+}
+
+func TestSectionNativesConsistentAcrossAWidenedDOMChainSweep(t *testing.T) {
+	r := probes(t, honestNativePayload(domChainNativeMembers))
+	s := section(t, Analyze(r, Inputs{}), "natives")
+	if s.Determination != Consistent {
+		t.Fatalf("determination = %q, want %q: every requirement held on every accessor, across five prototypes, exactly as the four-member navigator-only sweep already reports it", s.Determination, Consistent)
+	}
+}
+
+func TestSectionNativesInstrumentedNamesOnlyTheDOMChainMemberThatFailed(t *testing.T) {
+	kv := honestNativePayload(domChainNativeMembers)
+	kv["native.receiver"] = ok(`{"navigator.platform":{"threw":true,"name":"TypeError"},` +
+		`"screen.width":{"threw":true,"name":"TypeError"},` +
+		`"Node.prototype.nodeType":{"threw":false,"resultType":"number"},` +
+		`"Node.prototype.textContent":{"threw":true,"name":"TypeError"},` +
+		`"Element.prototype.tagName":{"threw":true,"name":"TypeError"},` +
+		`"Element.prototype.getAttribute":{"threw":true,"name":"TypeError"},` +
+		`"EventTarget.prototype.addEventListener":{"threw":true,"name":"TypeError"},` +
+		`"HTMLElement.prototype.click":{"threw":true,"name":"TypeError"},` +
+		`"Document.prototype.createElement":{"threw":true,"name":"TypeError"}}`)
+	r := probes(t, kv)
+	s := section(t, Analyze(r, Inputs{}), "natives")
+	if s.Determination != Instrumented {
+		t.Fatalf("determination = %q, want %q", s.Determination, Instrumented)
+	}
+	sawFailing, sawOthers := false, false
+	for _, row := range s.Rows {
+		if row.Label == "Node.prototype.nodeType" {
+			sawFailing = true
+		}
+		for _, other := range []string{"textContent", "tagName", "getAttribute", "addEventListener", "click", "createElement", "navigator.platform", "screen.width"} {
+			if row.Label == other || row.Label == "Element.prototype."+other || row.Label == "EventTarget.prototype."+other || row.Label == "HTMLElement.prototype."+other || row.Label == "Document.prototype."+other || row.Label == "Node.prototype."+other {
+				sawOthers = true
+			}
+		}
+	}
+	if !sawFailing {
+		t.Errorf("no row named the one accessor that failed its brand check")
+	}
+	if sawOthers {
+		t.Errorf("a row named an accessor whose evidence came through cleanly; a disagreement must only be excused, or reported, for the accessor its own evidence came through")
+	}
+}
+
+func TestWideningTheDOMChainSweepDoesNotMoveTheHonestScore(t *testing.T) {
+	narrow := []struct {
+		id     string
+		name   string
+		getter bool
+	}{
+		{"navigator.platform", "platform", true},
+		{"screen.width", "width", true},
+	}
+	baseSections := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+	}
+
+	narrowReq := probes(t, honestNativePayload(narrow))
+	narrowSection := sectionNatives(narrowReq, Inputs{}, readClaim(narrowReq))
+	narrowSection.ID = "natives"
+	before := summarise(append(append([]Section{}, baseSections...), normalise(narrowSection)))
+
+	wideReq := probes(t, honestNativePayload(domChainNativeMembers))
+	wideSection := sectionNatives(wideReq, Inputs{}, readClaim(wideReq))
+	wideSection.ID = "natives"
+	after := summarise(append(append([]Section{}, baseSections...), normalise(wideSection)))
+
+	if before.Band != after.Band {
+		t.Errorf("band moved from %q to %q merely by widening how many accessors an honest, agreeing sweep examined", before.Band, after.Band)
+	}
+	if before.HumanConfidence != after.HumanConfidence {
+		t.Errorf("human confidence moved from %d to %d merely by widening the sweep", before.HumanConfidence, after.HumanConfidence)
+	}
+	if before.BotLikeness != after.BotLikeness {
+		t.Errorf("bot likeness moved from %d to %d merely by widening the sweep", before.BotLikeness, after.BotLikeness)
+	}
+	if narrowSection.Determination != Consistent || wideSection.Determination != Consistent {
+		t.Fatalf("both the narrow and the widened sweep must agree on an honest payload: narrow=%q wide=%q", narrowSection.Determination, wideSection.Determination)
+	}
+}
+
+func TestSectionNativesStillAbstainsWithNoDOMChainDataAtAll(t *testing.T) {
+	r := probes(t, map[string]string{})
+	s := section(t, Analyze(r, Inputs{}), "natives")
+	if s.Determination == Contradiction || s.Determination == Instrumented {
+		t.Fatalf("determination = %q on a payload with no native.* data at all; absence must never score", s.Determination)
+	}
+}

--- a/internal/scan/sec_permissions.go
+++ b/internal/scan/sec_permissions.go
@@ -11,7 +11,12 @@ func sectionPermissions(r Request, _ Inputs, _ claim) Section {
 
 	raw, ok := r.value("perm.state")
 	if !ok {
-		s.Rows = append(s.Rows, Row{Label: "permission state", Value: "not collected", Note: "the collector did not report it"})
+		s.Determination = Unverified
+		s.Rows = append(s.Rows, Row{
+			Label: "permission state",
+			Value: "not collected",
+			Note:  "this reading compares two interfaces reporting the same permission; a payload that names neither leaves it nothing to apply to, so it carries no weight either way",
+		})
 		return s
 	}
 
@@ -31,6 +36,15 @@ func sectionPermissions(r Request, _ Inputs, _ claim) Section {
 	s.Rows = append(s.Rows, Row{Label: "Permissions.query for notifications", Value: valueOrAbsent(queried), Note: "the permission state"})
 	s.Rows = append(s.Rows, Row{Label: "Notification.permission", Value: valueOrAbsent(actual), Note: "the same permission, read through the other interface"})
 
+	if queried == "" && actual == "" {
+		s.Determination = Unverified
+		s.Rows = append(s.Rows, Row{
+			Label: "conclusion",
+			Value: "neither reading was reported",
+			Note:  "an observation was collected but named neither interface, so this reading has nothing to apply to",
+		})
+		return s
+	}
 	if queried == "" || actual == "" {
 		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "only one of the two readings was reported", Note: "nothing was compared"})
 		return s

--- a/internal/scan/sec_permissions.go
+++ b/internal/scan/sec_permissions.go
@@ -46,15 +46,17 @@ func sectionPermissions(r Request, _ Inputs, _ claim) Section {
 		return s
 	}
 	if queried == "" || actual == "" {
-		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "only one of the two readings was reported", Note: "nothing was compared"})
+		s.Determination = Unverified
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "only one of the two readings was reported", Note: "a comparison needs both, so this reading has nothing to apply to"})
 		return s
 	}
 	want, known := notificationEquivalent[queried]
 	if !known {
+		s.Determination = Unverified
 		s.Rows = append(s.Rows, Row{
 			Label: "conclusion",
 			Value: "the reported state is not one this project's table knows",
-			Note:  "treated as unknown, not as wrong",
+			Note:  "a state this project cannot place carries no weight, in either direction",
 		})
 		return s
 	}

--- a/internal/scan/sec_permissions_test.go
+++ b/internal/scan/sec_permissions_test.go
@@ -26,17 +26,17 @@ func TestPermissionsIsUnverifiedWhenTheObservationNamesNeitherInterface(t *testi
 	}
 }
 
-func TestPermissionsAbstainsWhenOnlyOneInterfaceWasReported(t *testing.T) {
+func TestPermissionsCarriesNoWeightWhenOnlyOneInterfaceWasReported(t *testing.T) {
 	got := sectionPermissions(permissionsRequest(t, `{"notifications":{"query":"prompt"}}`), Inputs{}, claim{})
-	if got.Determination != Inconclusive {
-		t.Fatalf("determination = %q, want %q: one interface reporting is not two facts to compare", got.Determination, Inconclusive)
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: one interface reporting is not two facts to compare, so the reading has nothing to apply to", got.Determination, Unverified)
 	}
 }
 
-func TestPermissionsAbstainsOnAnUntabulatedState(t *testing.T) {
+func TestPermissionsCarriesNoWeightOnAnUntabulatedState(t *testing.T) {
 	got := sectionPermissions(permissionsRequest(t, `{"notifications":{"query":"unknown-state","actual":"default"}}`), Inputs{}, claim{})
-	if got.Determination != Inconclusive {
-		t.Fatalf("determination = %q, want %q: a state this project's table does not know must not be read as wrong", got.Determination, Inconclusive)
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: a state this project's table cannot place carries no weight", got.Determination, Unverified)
 	}
 }
 
@@ -114,5 +114,38 @@ func TestPermissionsIsOneOfTheSectionsAnalyzeBuilds(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("the reading is not registered in the section order, so no scan runs it")
+	}
+}
+
+func TestPermissionsCarriesNoWeightOnEveryPathThatSettlesNothing(t *testing.T) {
+	bodies := map[string]string{
+		"not collected":            "",
+		"neither interface named":  `{"geolocation":{"query":"prompt"}}`,
+		"only the query reported":  `{"notifications":{"query":"prompt"}}`,
+		"only the other reported":  `{"notificationPermission":"default"}`,
+		"a state this table lacks": `{"notifications":{"query":"somethingelse","actual":"default"}}`,
+	}
+
+	settled := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Inconclusive},
+	}
+	before := summarise(settled)
+
+	for name, body := range bodies {
+		r := Request{Probes: map[string]Probe{}}
+		if body != "" {
+			r.Probes["perm.state"] = Probe{Status: StatusOK, Value: []byte(body)}
+		}
+		got := sectionPermissions(r, Inputs{}, claim{})
+		if got.Determination != Unverified {
+			t.Errorf("%s: determination = %q, want %q", name, got.Determination, Unverified)
+		}
+		got.ID = "permissions"
+		after := summarise(append(settled, normalise(got)))
+		if after.Band != before.Band || after.HumanConfidence != before.HumanConfidence || after.BotLikeness != before.BotLikeness {
+			t.Errorf("%s: the summary moved from %+v to %+v", name, before, after)
+		}
 	}
 }

--- a/internal/scan/sec_permissions_test.go
+++ b/internal/scan/sec_permissions_test.go
@@ -1,0 +1,118 @@
+package scan
+
+import "testing"
+
+func permissionsRequest(t *testing.T, body string) Request {
+	t.Helper()
+	if body == "" {
+		return Request{Probes: map[string]Probe{}}
+	}
+	return Request{Probes: map[string]Probe{
+		"perm.state": {Status: StatusOK, Value: []byte(body)},
+	}}
+}
+
+func TestPermissionsIsUnverifiedWhenNothingWasCollected(t *testing.T) {
+	got := sectionPermissions(permissionsRequest(t, ""), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: a payload with no permission observation leaves this reading nothing to apply to", got.Determination, Unverified)
+	}
+}
+
+func TestPermissionsIsUnverifiedWhenTheObservationNamesNeitherInterface(t *testing.T) {
+	got := sectionPermissions(permissionsRequest(t, `{}`), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q", got.Determination, Unverified)
+	}
+}
+
+func TestPermissionsAbstainsWhenOnlyOneInterfaceWasReported(t *testing.T) {
+	got := sectionPermissions(permissionsRequest(t, `{"notifications":{"query":"prompt"}}`), Inputs{}, claim{})
+	if got.Determination != Inconclusive {
+		t.Fatalf("determination = %q, want %q: one interface reporting is not two facts to compare", got.Determination, Inconclusive)
+	}
+}
+
+func TestPermissionsAbstainsOnAnUntabulatedState(t *testing.T) {
+	got := sectionPermissions(permissionsRequest(t, `{"notifications":{"query":"unknown-state","actual":"default"}}`), Inputs{}, claim{})
+	if got.Determination != Inconclusive {
+		t.Fatalf("determination = %q, want %q: a state this project's table does not know must not be read as wrong", got.Determination, Inconclusive)
+	}
+}
+
+func TestPermissionsAgreesWhenBothInterfacesReportTheEquivalentState(t *testing.T) {
+	cases := []string{
+		`{"notifications":{"query":"granted","actual":"granted"}}`,
+		`{"notifications":{"query":"denied","actual":"denied"}}`,
+		`{"notifications":{"query":"prompt","actual":"default"}}`,
+	}
+	for _, body := range cases {
+		got := sectionPermissions(permissionsRequest(t, body), Inputs{}, claim{})
+		if got.Determination != Consistent {
+			t.Errorf("body %s: determination = %q, want %q", body, got.Determination, Consistent)
+		}
+	}
+}
+
+func TestPermissionsContradictsWhenTheTwoInterfacesDisagree(t *testing.T) {
+	got := sectionPermissions(permissionsRequest(t, `{"notifications":{"query":"denied","actual":"granted"}}`), Inputs{}, claim{})
+	if got.Determination != Contradiction {
+		t.Fatalf("determination = %q, want %q", got.Determination, Contradiction)
+	}
+}
+
+func TestPermissionsAcceptsTheOlderFlatShape(t *testing.T) {
+	got := sectionPermissions(permissionsRequest(t, `{"notifications":"granted","notificationPermission":"granted"}`), Inputs{}, claim{})
+	if got.Determination != Consistent {
+		t.Fatalf("determination = %q, want %q: this shape predates the nested one and must keep reading", got.Determination, Consistent)
+	}
+}
+
+func TestPermissionsNamesNoVendorInItsConclusion(t *testing.T) {
+	got := sectionPermissions(permissionsRequest(t, `{"notifications":{"query":"denied","actual":"granted"}}`), Inputs{}, claim{})
+	for _, row := range got.Rows {
+		if row.Label != "conclusion" {
+			continue
+		}
+		for _, forbidden := range []string{"Chrome", "Chromium", "Firefox", "Safari", "Edge"} {
+			if contains([]string{row.Value, row.Note}, forbidden) {
+				t.Errorf("the conclusion names %q: %q / %q", forbidden, row.Value, row.Note)
+			}
+		}
+	}
+}
+
+func TestPermissionsDoesNotDiluteAPayloadThatPredatesIt(t *testing.T) {
+	sections := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Inconclusive},
+	}
+	before := summarise(sections)
+
+	absent := sectionPermissions(permissionsRequest(t, ""), Inputs{}, claim{})
+	absent.ID = "permissions"
+	after := summarise(append(sections, normalise(absent)))
+
+	if before.Band != after.Band {
+		t.Errorf("band moved from %q to %q merely by adding a reading the payload has no data for", before.Band, after.Band)
+	}
+	if before.HumanConfidence != after.HumanConfidence {
+		t.Errorf("human confidence moved from %d to %d", before.HumanConfidence, after.HumanConfidence)
+	}
+	if before.BotLikeness != after.BotLikeness {
+		t.Errorf("bot likeness moved from %d to %d", before.BotLikeness, after.BotLikeness)
+	}
+}
+
+func TestPermissionsIsOneOfTheSectionsAnalyzeBuilds(t *testing.T) {
+	found := false
+	for _, s := range order {
+		if s.id == "permissions" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("the reading is not registered in the section order, so no scan runs it")
+	}
+}

--- a/internal/scan/sec_scopes.go
+++ b/internal/scan/sec_scopes.go
@@ -30,6 +30,9 @@ func sectionScopes(r Request, _ Inputs, _ claim) Section {
 		{"scope.main", "main thread"},
 		{"scope.worker", "dedicated worker"},
 		{"scope.iframe", "same-origin frame"},
+		{"scope.workerNested", "worker spawned by another worker"},
+		{"scope.iframeSrcdoc", "srcdoc frame"},
+		{"scope.iframeBlob", "frame loaded from a blob URL"},
 	}
 
 	values := map[string]any{}

--- a/internal/scan/sec_scopes_test.go
+++ b/internal/scan/sec_scopes_test.go
@@ -1,0 +1,148 @@
+package scan
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func mustJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func scopeProbe(userAgent, platform string, hwc float64, language string, languages []string, timeZone, locale string) Probe {
+	obj := map[string]any{
+		"userAgent":           userAgent,
+		"platform":            platform,
+		"hardwareConcurrency": hwc,
+	}
+	if language != "" {
+		obj["language"] = language
+	}
+	if len(languages) > 0 {
+		obj["languages"] = languages
+	}
+	if timeZone != "" {
+		obj["timeZone"] = timeZone
+	}
+	if locale != "" {
+		obj["locale"] = locale
+	}
+	return Probe{Status: StatusOK, Value: mustJSON(obj)}
+}
+
+func honestThreeScopeRequest(t *testing.T) Request {
+	t.Helper()
+	r := Request{Probes: map[string]Probe{}}
+	r.Probes["scope.main"] = scopeProbe("UA/1", "Win32", 8, "en-US", []string{"en-US", "en"}, "Asia/Bangkok", "en-US")
+	r.Probes["scope.worker"] = scopeProbe("UA/1", "Win32", 8, "en-US", []string{"en-US", "en"}, "Asia/Bangkok", "en-US")
+	r.Probes["scope.iframe"] = scopeProbe("UA/1", "Win32", 8, "en-US", []string{"en-US", "en"}, "Asia/Bangkok", "en-US")
+	return r
+}
+
+func TestScopesOldThreeScopePayloadStillReportsConsistent(t *testing.T) {
+	got := sectionScopes(honestThreeScopeRequest(t), Inputs{}, claim{})
+	if got.Determination != Consistent {
+		t.Fatalf("determination = %q, want %q: a payload carrying only scope.main, scope.worker and scope.iframe must score exactly as it did before the new realms were added", got.Determination, Consistent)
+	}
+}
+
+func TestScopesOldThreeScopePayloadDoesNotMoveTheSummaryComparedToBeforeTheNewRealmsExisted(t *testing.T) {
+	sections := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Inconclusive},
+	}
+
+	got := sectionScopes(honestThreeScopeRequest(t), Inputs{}, claim{})
+	got.ID = "scopes"
+
+	withOldReading := summarise(append(append([]Section{}, sections...), normalise(Section{ID: "scopes", Determination: Consistent})))
+	withCurrentCode := summarise(append(sections, normalise(got)))
+
+	if withOldReading.Band != withCurrentCode.Band {
+		t.Errorf("band moved from %q to %q for a payload that predates the new realms", withOldReading.Band, withCurrentCode.Band)
+	}
+	if withOldReading.HumanConfidence != withCurrentCode.HumanConfidence {
+		t.Errorf("human confidence moved from %d to %d for a payload that predates the new realms", withOldReading.HumanConfidence, withCurrentCode.HumanConfidence)
+	}
+	if withOldReading.BotLikeness != withCurrentCode.BotLikeness {
+		t.Errorf("bot likeness moved from %d to %d for a payload that predates the new realms", withOldReading.BotLikeness, withCurrentCode.BotLikeness)
+	}
+}
+
+func TestScopesNewRealmsAgreeingStillReportConsistent(t *testing.T) {
+	r := honestThreeScopeRequest(t)
+	r.Probes["scope.workerNested"] = scopeProbe("UA/1", "Win32", 8, "", nil, "", "")
+	r.Probes["scope.iframeSrcdoc"] = scopeProbe("UA/1", "Win32", 8, "en-US", []string{"en-US", "en"}, "Asia/Bangkok", "en-US")
+	r.Probes["scope.iframeBlob"] = scopeProbe("UA/1", "Win32", 8, "en-US", []string{"en-US", "en"}, "Asia/Bangkok", "en-US")
+
+	got := sectionScopes(r, Inputs{}, claim{})
+	if got.Determination != Consistent {
+		t.Fatalf("determination = %q, want %q: every realm reported the same facts, including two workers honestly missing timeZone/locale", got.Determination, Consistent)
+	}
+}
+
+func TestScopesASrcdocFrameThatDisagreesIsInstrumented(t *testing.T) {
+	r := honestThreeScopeRequest(t)
+	r.Probes["scope.iframeSrcdoc"] = scopeProbe("UA/DIFFERENT", "Win32", 8, "", nil, "", "")
+
+	got := sectionScopes(r, Inputs{}, claim{})
+	if got.Determination != Instrumented {
+		t.Fatalf("determination = %q, want %q: the srcdoc frame's userAgent does not match the other scopes of the same page", got.Determination, Instrumented)
+	}
+}
+
+func TestScopesANestedWorkerThatDisagreesIsInstrumented(t *testing.T) {
+	r := honestThreeScopeRequest(t)
+	r.Probes["scope.workerNested"] = scopeProbe("UA/1", "Linux armv7l", 8, "", nil, "", "")
+
+	got := sectionScopes(r, Inputs{}, claim{})
+	if got.Determination != Instrumented {
+		t.Fatalf("determination = %q, want %q: the nested worker's platform does not match the other scopes of the same page", got.Determination, Instrumented)
+	}
+}
+
+func TestScopesARealmThatCouldNotBeCreatedIsNotEvidence(t *testing.T) {
+	r := honestThreeScopeRequest(t)
+	r.Probes["scope.workerNested"] = Probe{Status: StatusUnsupported}
+
+	got := sectionScopes(r, Inputs{}, claim{})
+	if got.Determination != Consistent {
+		t.Fatalf("determination = %q, want %q: a browser that refused to create a realm must score exactly as one that created it and agreed", got.Determination, Consistent)
+	}
+	found := false
+	for _, row := range got.Rows {
+		if row.Label == "worker spawned by another worker" && row.Value == "the browser would not create this scope" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a row explaining the nested worker was never created, got %+v", got.Rows)
+	}
+}
+
+func TestScopesAnErroredRealmIsNotEvidence(t *testing.T) {
+	r := honestThreeScopeRequest(t)
+	r.Probes["scope.iframeSrcdoc"] = Probe{Status: StatusError}
+
+	got := sectionScopes(r, Inputs{}, claim{})
+	if got.Determination != Consistent {
+		t.Fatalf("determination = %q, want %q: a scope the collector could not read from must not lower the score", got.Determination, Consistent)
+	}
+}
+
+func TestScopesIsOneOfTheSectionsAnalyzeBuilds(t *testing.T) {
+	found := false
+	for _, s := range order {
+		if s.id == "scopes" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("the reading is not registered in the section order, so no scan runs it")
+	}
+}

--- a/internal/scan/sec_viewport.go
+++ b/internal/scan/sec_viewport.go
@@ -1,11 +1,10 @@
 package scan
 
 func sectionViewport(r Request, _ Inputs, _ claim) Section {
-	s := Section{Determination: Inconclusive}
+	s := Section{Determination: Unverified}
 
 	geom, ok := r.value("geom.screen")
 	if !ok {
-		s.Determination = Unverified
 		s.Rows = append(s.Rows, Row{
 			Label: "screen and viewport",
 			Value: "not collected",
@@ -23,7 +22,6 @@ func sectionViewport(r Request, _ Inputs, _ claim) Section {
 	s.Rows = append(s.Rows, Row{Label: "viewport, as reported", Value: dimension(innerW, haveInnerW, innerH, haveInnerH), Note: "the size of the area this page was given to draw in"})
 
 	if !haveScreenW || !haveScreenH || !haveInnerW || !haveInnerH {
-		s.Determination = Unverified
 		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "one of the four numbers was not reported", Note: "nothing was compared, and this reading carries no weight"})
 		return s
 	}

--- a/internal/scan/sec_viewport.go
+++ b/internal/scan/sec_viewport.go
@@ -1,0 +1,77 @@
+package scan
+
+func sectionViewport(r Request, _ Inputs, _ claim) Section {
+	s := Section{Determination: Inconclusive}
+
+	geom, ok := r.value("geom.screen")
+	if !ok {
+		s.Determination = Unverified
+		s.Rows = append(s.Rows, Row{
+			Label: "screen and viewport",
+			Value: "not collected",
+			Note:  "this reading compares a viewport against the screen it is displayed on; without both it carries no weight either way",
+		})
+		return s
+	}
+
+	screenW, haveScreenW := num(geom, "width")
+	screenH, haveScreenH := num(geom, "height")
+	innerW, haveInnerW := num(geom, "innerWidth")
+	innerH, haveInnerH := num(geom, "innerHeight")
+
+	s.Rows = append(s.Rows, Row{Label: "screen, as reported", Value: dimension(screenW, haveScreenW, screenH, haveScreenH), Note: "the size of the output device this environment says it is displayed on"})
+	s.Rows = append(s.Rows, Row{Label: "viewport, as reported", Value: dimension(innerW, haveInnerW, innerH, haveInnerH), Note: "the size of the area this page was given to draw in"})
+
+	if !haveScreenW || !haveScreenH || !haveInnerW || !haveInnerH {
+		s.Determination = Unverified
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "one of the four numbers was not reported", Note: "nothing was compared, and this reading carries no weight"})
+		return s
+	}
+	if screenW <= 0 || screenH <= 0 || innerW <= 0 || innerH <= 0 {
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "a reported size was zero or negative", Note: "a screen or viewport of no size settles nothing"})
+		return s
+	}
+
+	offsetX, haveOffsetX := num(geom, "screenX")
+	offsetY, haveOffsetY := num(geom, "screenY")
+	if (haveOffsetX && offsetX < 0) || (haveOffsetY && offsetY < 0) {
+		s.Rows = append(s.Rows, Row{Label: "window offset", Value: offset(offsetX, haveOffsetX, offsetY, haveOffsetY), Note: "an offset before the origin places this window on a display other than the one measured, whose size this reading was not given"})
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "the window is not positioned on the screen that was measured", Note: "nothing was compared"})
+		return s
+	}
+
+	if innerH > screenH || innerW > screenW {
+		s.Determination = Contradiction
+		s.Rows = append(s.Rows, Row{
+			Label: "conclusion",
+			Value: "the area this page was given is larger than the screen it is said to be displayed on",
+			Note:  "both are reported in the same units and scale together, so a viewport cannot exceed its own output device",
+		})
+		return s
+	}
+
+	s.Determination = Consistent
+	s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "the viewport fits within the screen this environment claims", Note: ""})
+	return s
+}
+
+func dimension(w float64, haveW bool, h float64, haveH bool) string {
+	if !haveW || !haveH {
+		return "not reported"
+	}
+	return itoa(w) + " by " + itoa(h)
+}
+
+func offset(x float64, haveX bool, y float64, haveY bool) string {
+	if !haveX && !haveY {
+		return "not reported"
+	}
+	left, top := "not reported", "not reported"
+	if haveX {
+		left = itoa(x)
+	}
+	if haveY {
+		top = itoa(y)
+	}
+	return left + " from the left, " + top + " from the top"
+}

--- a/internal/scan/sec_viewport_test.go
+++ b/internal/scan/sec_viewport_test.go
@@ -1,0 +1,151 @@
+package scan
+
+import (
+	"strconv"
+	"testing"
+)
+
+type viewportNumbers struct {
+	screenW, screenH int
+	innerW, innerH   int
+	screenX, screenY int
+	omit             string
+	devicePixelRatio string
+}
+
+func viewportRequest(t *testing.T, n viewportNumbers) Request {
+	t.Helper()
+	dpr := n.devicePixelRatio
+	if dpr == "" {
+		dpr = "1"
+	}
+	fields := map[string]string{
+		"width":            strconv.Itoa(n.screenW),
+		"height":           strconv.Itoa(n.screenH),
+		"innerWidth":       strconv.Itoa(n.innerW),
+		"innerHeight":      strconv.Itoa(n.innerH),
+		"screenX":          strconv.Itoa(n.screenX),
+		"screenY":          strconv.Itoa(n.screenY),
+		"devicePixelRatio": dpr,
+	}
+	delete(fields, n.omit)
+
+	body := "{"
+	first := true
+	for _, key := range []string{"width", "height", "innerWidth", "innerHeight", "screenX", "screenY", "devicePixelRatio"} {
+		v, ok := fields[key]
+		if !ok {
+			continue
+		}
+		if !first {
+			body += ","
+		}
+		first = false
+		body += `"` + key + `":` + v
+	}
+	body += "}"
+
+	return Request{Probes: map[string]Probe{"geom.screen": {Status: StatusOK, Value: []byte(body)}}}
+}
+
+var viewportFits = viewportNumbers{screenW: 1920, screenH: 1080, innerW: 928, innerH: 794}
+
+func TestViewportAgreesWhenItFitsTheScreenItClaims(t *testing.T) {
+	got := sectionViewport(viewportRequest(t, viewportFits), Inputs{}, claim{})
+	if got.Determination != Consistent {
+		t.Fatalf("determination = %q, want %q", got.Determination, Consistent)
+	}
+}
+
+func TestViewportReportsContradictionWhenItIsTallerThanTheScreen(t *testing.T) {
+	n := viewportFits
+	n.screenH, n.innerH = 768, 794
+	got := sectionViewport(viewportRequest(t, n), Inputs{}, claim{})
+	if got.Determination != Contradiction {
+		t.Fatalf("determination = %q, want %q", got.Determination, Contradiction)
+	}
+}
+
+func TestViewportReportsContradictionWhenItIsWiderThanTheScreen(t *testing.T) {
+	n := viewportFits
+	n.screenW, n.innerW = 800, 928
+	got := sectionViewport(viewportRequest(t, n), Inputs{}, claim{})
+	if got.Determination != Contradiction {
+		t.Fatalf("determination = %q, want %q", got.Determination, Contradiction)
+	}
+}
+
+func TestViewportAcceptsAWindowHangingOffTheBottomOfItsScreen(t *testing.T) {
+	n := viewportFits
+	n.screenH, n.innerH, n.screenY = 900, 794, 300
+	got := sectionViewport(viewportRequest(t, n), Inputs{}, claim{})
+	if got.Determination == Contradiction {
+		t.Fatal("a window positioned so its lower part is off the screen is ordinary, not a contradiction")
+	}
+}
+
+func TestViewportAbstainsWhenTheWindowSitsLeftOfOrAboveTheOrigin(t *testing.T) {
+	for _, n := range []viewportNumbers{
+		{screenW: 1920, screenH: 768, innerW: 928, innerH: 794, screenY: -200},
+		{screenW: 800, screenH: 1080, innerW: 928, innerH: 794, screenX: -300},
+	} {
+		got := sectionViewport(viewportRequest(t, n), Inputs{}, claim{})
+		if got.Determination != Inconclusive {
+			t.Errorf("%+v: determination = %q, want %q: a negative offset means another display, whose size this reading was not given", n, got.Determination, Inconclusive)
+		}
+	}
+}
+
+func TestViewportCarriesNoWeightWhenTheNumbersWereNotCollected(t *testing.T) {
+	got := sectionViewport(Request{Probes: map[string]Probe{}}, Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q", got.Determination, Unverified)
+	}
+}
+
+func TestViewportCarriesNoWeightWhenAnyNumberIsMissing(t *testing.T) {
+	for _, omit := range []string{"width", "height", "innerWidth", "innerHeight"} {
+		n := viewportFits
+		n.omit = omit
+		got := sectionViewport(viewportRequest(t, n), Inputs{}, claim{})
+		if got.Determination != Unverified {
+			t.Errorf("omitting %q: determination = %q, want %q", omit, got.Determination, Unverified)
+		}
+	}
+}
+
+func TestViewportAbstainsOnAScreenOfNoSize(t *testing.T) {
+	n := viewportFits
+	n.screenW, n.screenH = 0, 0
+	got := sectionViewport(viewportRequest(t, n), Inputs{}, claim{})
+	if got.Determination == Contradiction {
+		t.Fatal("a screen reported as having no size settles nothing")
+	}
+}
+
+func TestViewportIsOneOfTheSectionsAnalyzeBuilds(t *testing.T) {
+	found := false
+	for _, s := range order {
+		if s.id == "viewport" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("the reading is not registered in the section order, so no scan runs it")
+	}
+}
+
+func TestViewportNamesNoVendorInItsConclusion(t *testing.T) {
+	n := viewportFits
+	n.screenH, n.innerH = 768, 794
+	got := sectionViewport(viewportRequest(t, n), Inputs{}, claim{})
+	saw := false
+	for _, row := range got.Rows {
+		if row.Label == "conclusion" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatal("the reading reports no conclusion row")
+	}
+}

--- a/internal/scan/sec_viewport_test.go
+++ b/internal/scan/sec_viewport_test.go
@@ -84,14 +84,14 @@ func TestViewportAcceptsAWindowHangingOffTheBottomOfItsScreen(t *testing.T) {
 	}
 }
 
-func TestViewportAbstainsWhenTheWindowSitsLeftOfOrAboveTheOrigin(t *testing.T) {
+func TestViewportCarriesNoWeightWhenTheWindowSitsLeftOfOrAboveTheOrigin(t *testing.T) {
 	for _, n := range []viewportNumbers{
 		{screenW: 1920, screenH: 768, innerW: 928, innerH: 794, screenY: -200},
 		{screenW: 800, screenH: 1080, innerW: 928, innerH: 794, screenX: -300},
 	} {
 		got := sectionViewport(viewportRequest(t, n), Inputs{}, claim{})
-		if got.Determination != Inconclusive {
-			t.Errorf("%+v: determination = %q, want %q: a negative offset means another display, whose size this reading was not given", n, got.Determination, Inconclusive)
+		if got.Determination != Unverified {
+			t.Errorf("%+v: determination = %q, want %q: a negative offset means another display, whose size this reading was not given, and a layout this ordinary must not cost an honest browser anything", n, got.Determination, Unverified)
 		}
 	}
 }
@@ -114,12 +114,44 @@ func TestViewportCarriesNoWeightWhenAnyNumberIsMissing(t *testing.T) {
 	}
 }
 
-func TestViewportAbstainsOnAScreenOfNoSize(t *testing.T) {
+func TestViewportCarriesNoWeightOnAScreenOfNoSize(t *testing.T) {
 	n := viewportFits
 	n.screenW, n.screenH = 0, 0
 	got := sectionViewport(viewportRequest(t, n), Inputs{}, claim{})
-	if got.Determination == Contradiction {
-		t.Fatal("a screen reported as having no size settles nothing")
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: a screen reported as having no size settles nothing", got.Determination, Unverified)
+	}
+}
+
+func TestViewportCarriesNoWeightOnEveryPathThatSettlesNothing(t *testing.T) {
+	cases := []struct {
+		name string
+		req  Request
+	}{
+		{"not collected", Request{Probes: map[string]Probe{}}},
+		{"a number missing", viewportRequest(t, viewportNumbers{screenW: 1920, screenH: 1080, innerW: 928, innerH: 794, omit: "height"})},
+		{"a window on a display above the origin", viewportRequest(t, viewportNumbers{screenW: 1920, screenH: 768, innerW: 928, innerH: 794, screenY: -200})},
+		{"a window on a display left of the origin", viewportRequest(t, viewportNumbers{screenW: 800, screenH: 1080, innerW: 928, innerH: 794, screenX: -300})},
+		{"a screen of no size", viewportRequest(t, viewportNumbers{screenW: 0, screenH: 0, innerW: 928, innerH: 794})},
+	}
+
+	settled := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Inconclusive},
+	}
+	before := summarise(settled)
+
+	for _, c := range cases {
+		got := sectionViewport(c.req, Inputs{}, claim{})
+		if got.Determination != Unverified {
+			t.Errorf("%s: determination = %q, want %q", c.name, got.Determination, Unverified)
+		}
+		got.ID = "viewport"
+		after := summarise(append(settled, normalise(got)))
+		if after.Band != before.Band || after.HumanConfidence != before.HumanConfidence || after.BotLikeness != before.BotLikeness {
+			t.Errorf("%s: the summary moved from %+v to %+v", c.name, before, after)
+		}
 	}
 }
 

--- a/internal/scan/sec_webgpu.go
+++ b/internal/scan/sec_webgpu.go
@@ -1,0 +1,94 @@
+package scan
+
+import "strings"
+
+var softwareRasteriserMarkers = []string{
+	"swiftshader",
+	"llvmpipe",
+	"basic render",
+	"software adapter",
+	"software rasterizer",
+	"microsoft basic",
+}
+
+var webgpuHardwarePaths = []string{"default", "highPerformance", "lowPower"}
+
+func sectionWebGPU(r Request, _ Inputs, _ claim) Section {
+	s := Section{Determination: Inconclusive}
+
+	adapter, ok := r.value("gpu.adapter")
+	if !ok {
+		return webgpuNoWeight(s, "the adapter interface was not collected", "this reading compares a named device against the adapters granted for it; without the adapters it carries no weight either way")
+	}
+
+	if secure, known := boolean(adapter, "secureContext"); known && !secure {
+		return webgpuNoWeight(s, "the page was not delivered to a secure context", "the interface is gated there, so nothing follows from its answer")
+	}
+	if present, known := boolean(adapter, "present"); !known || !present {
+		return webgpuNoWeight(s, "this browser does not expose the interface", "a browser is never read as lacking a feature")
+	}
+
+	renderer, named := hwDecodeRenderer(r)
+	if !named {
+		return webgpuNoWeight(s, "no graphics device was named", "with no device named there is nothing for an empty adapter to disagree with")
+	}
+	s.Rows = append(s.Rows, Row{Label: "graphics device, as reported", Value: clip(renderer, 90), Note: "read through the older of the two graphics interfaces"})
+
+	if isSoftwareRasteriser(renderer) {
+		return webgpuNoWeight(s, "the device named draws in software", "an environment already drawing in software is not contradicted by having no hardware adapter")
+	}
+
+	granted, missing := 0, 0
+	for _, path := range webgpuHardwarePaths {
+		got, known := boolean(adapter, "variants", path, "adapter")
+		if !known {
+			return webgpuNoWeight(s, "one of the adapter requests was not reported", "nothing was compared")
+		}
+		if got {
+			granted++
+		} else {
+			missing++
+		}
+		s.Rows = append(s.Rows, Row{Label: "adapter for the " + webgpuPathLabel(path) + " request", Value: answerOrAbsent(got, true), Note: ""})
+	}
+
+	if granted > 0 {
+		s.Determination = Consistent
+		s.Rows = append(s.Rows, Row{Label: "conclusion", Value: "the newer graphics interface reaches a device too", Note: "a request for a software fallback is not read here, because a machine with real hardware ordinarily has no software backend to offer"})
+		return s
+	}
+
+	s.Determination = Instrumented
+	s.Rows = append(s.Rows, Row{
+		Label: "conclusion",
+		Value: "one graphics interface names a hardware device and the other reaches no device at all",
+		Note:  "both interfaces address the same device, so this reports that something between them has been changed; a policy or a driver may be what changed it, which is why this is read as a modification rather than as a false claim",
+	})
+	return s
+}
+
+func webgpuNoWeight(s Section, value, note string) Section {
+	s.Determination = Unverified
+	s.Rows = append(s.Rows, Row{Label: "conclusion", Value: value, Note: note})
+	return s
+}
+
+func webgpuPathLabel(path string) string {
+	switch path {
+	case "highPerformance":
+		return "high performance"
+	case "lowPower":
+		return "low power"
+	}
+	return "unqualified"
+}
+
+func isSoftwareRasteriser(renderer string) bool {
+	lower := strings.ToLower(renderer)
+	for _, marker := range softwareRasteriserMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scan/sec_webgpu_test.go
+++ b/internal/scan/sec_webgpu_test.go
@@ -1,0 +1,140 @@
+package scan
+
+import "testing"
+
+const hardwareRenderer = "ANGLE (NVIDIA, NVIDIA GeForce RTX 3060 Ti (0x00002489) Direct3D11 vs_5_0 ps_5_0, D3D11)"
+
+func webgpuRequest(t *testing.T, adapter string, renderer string) Request {
+	t.Helper()
+	r := Request{Probes: map[string]Probe{}}
+	if adapter != "" {
+		r.Probes["gpu.adapter"] = Probe{Status: StatusOK, Value: []byte(adapter)}
+	}
+	if renderer != "" {
+		r.Probes["gpu.renderer"] = Probe{Status: StatusOK, Value: []byte(`{"unmaskedRenderer":"` + renderer + `"}`)}
+	}
+	return r
+}
+
+const adapterNoneAnywhere = `{"present":true,"secureContext":true,"variants":{
+	"default":{"adapter":false},
+	"highPerformance":{"adapter":false},
+	"lowPower":{"adapter":false},
+	"fallback":{"adapter":false}}}`
+
+const adapterOnlyFallbackMissing = `{"present":true,"secureContext":true,"variants":{
+	"default":{"adapter":true,"vendor":"nvidia","architecture":"ampere","maxTextureDimension2D":16384},
+	"highPerformance":{"adapter":true,"vendor":"nvidia","architecture":"ampere","maxTextureDimension2D":16384},
+	"lowPower":{"adapter":true,"vendor":"nvidia","architecture":"ampere","maxTextureDimension2D":16384},
+	"fallback":{"adapter":false}}}`
+
+func TestWebGPUReportsModificationWhenHardwareIsNamedAndNoAdapterIsGranted(t *testing.T) {
+	got := sectionWebGPU(webgpuRequest(t, adapterNoneAnywhere, hardwareRenderer), Inputs{}, claim{})
+	if got.Determination != Instrumented {
+		t.Fatalf("determination = %q, want %q", got.Determination, Instrumented)
+	}
+}
+
+func TestWebGPUAgreesWhenOnlyTheFallbackPathIsEmpty(t *testing.T) {
+	got := sectionWebGPU(webgpuRequest(t, adapterOnlyFallbackMissing, hardwareRenderer), Inputs{}, claim{})
+	if got.Determination != Consistent {
+		t.Fatalf("determination = %q, want %q: no software backend on a machine with real hardware is ordinary", got.Determination, Consistent)
+	}
+}
+
+func TestWebGPUCarriesNoWeightWhenItWasNotCollected(t *testing.T) {
+	got := sectionWebGPU(webgpuRequest(t, "", hardwareRenderer), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q", got.Determination, Unverified)
+	}
+}
+
+func TestWebGPUCarriesNoWeightWhenTheInterfaceIsAbsent(t *testing.T) {
+	body := `{"present":false,"secureContext":true,"variants":{}}`
+	got := sectionWebGPU(webgpuRequest(t, body, hardwareRenderer), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: a browser without the interface is never scored for lacking it", got.Determination, Unverified)
+	}
+}
+
+func TestWebGPUCarriesNoWeightOutsideASecureContext(t *testing.T) {
+	body := `{"present":false,"secureContext":false,"variants":{}}`
+	got := sectionWebGPU(webgpuRequest(t, body, hardwareRenderer), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: the interface is gated here, so its absence says nothing", got.Determination, Unverified)
+	}
+}
+
+func TestWebGPUCarriesNoWeightWhenNoDeviceWasNamed(t *testing.T) {
+	got := sectionWebGPU(webgpuRequest(t, adapterNoneAnywhere, ""), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: with no device named there is nothing for the empty adapter to disagree with", got.Determination, Unverified)
+	}
+}
+
+func TestWebGPUCarriesNoWeightWhenTheDeviceNamedIsASoftwareRasteriser(t *testing.T) {
+	for _, renderer := range []string{
+		"Google SwiftShader",
+		"ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero)), SwiftShader driver)",
+		"Microsoft Basic Render Driver",
+		"llvmpipe (LLVM 15.0.7, 256 bits)",
+		"ANGLE (Software Adapter, Direct3D11 vs_5_0 ps_5_0, D3D11)",
+	} {
+		got := sectionWebGPU(webgpuRequest(t, adapterNoneAnywhere, renderer), Inputs{}, claim{})
+		if got.Determination != Unverified {
+			t.Errorf("renderer %q: determination = %q, want %q: an environment already drawing in software is not contradicted by having no hardware adapter", renderer, got.Determination, Unverified)
+		}
+	}
+}
+
+func TestWebGPUCarriesNoWeightWhenAPathWasNotReported(t *testing.T) {
+	body := `{"present":true,"secureContext":true,"variants":{"fallback":{"adapter":false}}}`
+	got := sectionWebGPU(webgpuRequest(t, body, hardwareRenderer), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q", got.Determination, Unverified)
+	}
+}
+
+func TestWebGPURaisesTenAndNoMore(t *testing.T) {
+	flagged := summarise([]Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Consistent},
+		{ID: "d", Determination: Consistent},
+		{ID: "webgpu", Determination: Instrumented},
+	})
+	if flagged.Band != BandInstrumented {
+		t.Fatalf("band = %q, want %q", flagged.Band, BandInstrumented)
+	}
+	if flagged.BotLikeness != 10 {
+		t.Fatalf("botLikeness = %d, want 10", flagged.BotLikeness)
+	}
+}
+
+func TestWebGPUDoesNotDiluteAPayloadThatPredatesIt(t *testing.T) {
+	sections := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Inconclusive},
+	}
+	before := summarise(sections)
+	absent := sectionWebGPU(Request{Probes: map[string]Probe{}}, Inputs{}, claim{})
+	absent.ID = "webgpu"
+	after := summarise(append(sections, normalise(absent)))
+
+	if before.Band != after.Band || before.HumanConfidence != after.HumanConfidence {
+		t.Errorf("adding a reading the payload has no data for moved the summary from %+v to %+v", before, after)
+	}
+}
+
+func TestWebGPUIsOneOfTheSectionsAnalyzeBuilds(t *testing.T) {
+	found := false
+	for _, s := range order {
+		if s.id == "webgpu" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("the reading is not registered in the section order, so no scan runs it")
+	}
+}

--- a/internal/scan/sec_webrtc.go
+++ b/internal/scan/sec_webrtc.go
@@ -1,0 +1,110 @@
+package scan
+
+var knownIceCandidateTypes = map[string]bool{
+	"host":  true,
+	"srflx": true,
+	"prflx": true,
+	"relay": true,
+}
+
+func sectionWebRTC(r Request, _ Inputs, _ claim) Section {
+	s := Section{Determination: Unverified}
+
+	if r.unsupported("webrtc.ice") {
+		s.Rows = append(s.Rows, Row{
+			Label: "ICE gathering",
+			Value: "reported unsupported",
+			Note:  "this browser does not offer the interface this reading watches; a browser is never read as lacking a feature",
+		})
+		return s
+	}
+
+	raw, ok := r.value("webrtc.ice")
+	if !ok {
+		s.Rows = append(s.Rows, Row{
+			Label: "ICE gathering",
+			Value: "not collected",
+			Note:  "this reading has nothing to read a gathering process's own machinery against, so it carries no weight either way",
+		})
+		return s
+	}
+
+	finalState, haveState := str(raw, "finalState")
+	timedOut, haveTimedOut := boolean(raw, "timedOut")
+	sawStates, _ := strList(raw, "sawStates")
+	candidateTypes, _ := strList(raw, "candidateTypes")
+
+	if !haveState || !haveTimedOut {
+		s.Rows = append(s.Rows, Row{
+			Label: "ICE gathering",
+			Value: "reported incompletely",
+			Note:  "the gathering state or the timeout flag was missing from the payload, so this reading cannot place what was measured",
+		})
+		return s
+	}
+
+	s.Rows = append(s.Rows, Row{
+		Label: "gathering state, at the end of this reading's watch",
+		Value: valueOrAbsent(finalState),
+		Note:  "the state the gathering process itself reported, not a state this reading assigns to it",
+	})
+	s.Rows = append(s.Rows, Row{
+		Label: "states observed in order",
+		Value: joinLimit(sawStates, 10),
+		Note:  "the sequence of iceGatheringState values this session transitioned through",
+	})
+	s.Rows = append(s.Rows, Row{
+		Label: "gathering reached its own deadline before finishing",
+		Value: answerOrAbsent(timedOut, true),
+		Note:  "when true, the state above is the last one observed, not a completed one",
+	})
+
+	counts := countIceCandidateTypes(candidateTypes)
+	for _, t := range []string{"host", "srflx", "prflx", "relay"} {
+		s.Rows = append(s.Rows, Row{
+			Label: "candidates of type " + t,
+			Value: itoa(float64(counts[t])),
+			Note:  "",
+		})
+	}
+	unknown := len(candidateTypes) - counts["host"] - counts["srflx"] - counts["prflx"] - counts["relay"]
+	if unknown > 0 {
+		s.Rows = append(s.Rows, Row{
+			Label: "candidates of an unrecognised type",
+			Value: itoa(float64(unknown)),
+			Note:  "reported by the gathering process under a type this reading does not know",
+		})
+	}
+
+	coherent := iceCoherent(finalState, timedOut, len(candidateTypes) > 0)
+	conclusion := "the candidate count and the gathering state this session reported are consistent with each other"
+	if !coherent {
+		conclusion = "the candidate count and the gathering state this session reported do not fit the shape this reading expects from one gathering process"
+	}
+	s.Rows = append(s.Rows, Row{
+		Label: "conclusion",
+		Value: conclusion,
+		Note:  "this reading only checks a gathering process against its own reported state; this project has not established what candidate count an honest environment of any given network configuration should produce, so it never carries a verdict, only a record of what the process reported about itself",
+	})
+	return s
+}
+
+func countIceCandidateTypes(types []string) map[string]int {
+	out := map[string]int{"host": 0, "srflx": 0, "prflx": 0, "relay": 0}
+	for _, t := range types {
+		if knownIceCandidateTypes[t] {
+			out[t]++
+		}
+	}
+	return out
+}
+
+func iceCoherent(finalState string, timedOut bool, haveCandidates bool) bool {
+	if timedOut {
+		return finalState != "complete"
+	}
+	if finalState == "complete" {
+		return true
+	}
+	return !haveCandidates
+}

--- a/internal/scan/sec_webrtc_test.go
+++ b/internal/scan/sec_webrtc_test.go
@@ -1,0 +1,152 @@
+package scan
+
+import "testing"
+
+func webrtcRequest(t *testing.T, finalState string, timedOut bool, sawStates, candidateTypes []string) Request {
+	t.Helper()
+	body := `{"finalState":"` + finalState + `","timedOut":` + jsonBool(timedOut) +
+		`,"sawStates":` + jsonStringArray(sawStates) +
+		`,"candidateTypes":` + jsonStringArray(candidateTypes) + `}`
+	return Request{Probes: map[string]Probe{
+		"webrtc.ice": {Status: StatusOK, Value: []byte(body)},
+	}}
+}
+
+func jsonStringArray(xs []string) string {
+	out := "["
+	for i, x := range xs {
+		if i > 0 {
+			out += ","
+		}
+		out += `"` + x + `"`
+	}
+	return out + "]"
+}
+
+func TestWebRTCIsUnverifiedWhenNothingWasCollected(t *testing.T) {
+	got := sectionWebRTC(Request{Probes: map[string]Probe{}}, Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: a payload with nothing to read leaves this reading nothing to apply to", got.Determination, Unverified)
+	}
+}
+
+func TestWebRTCIsUnverifiedWhenTheInterfaceIsReportedUnsupported(t *testing.T) {
+	r := Request{Probes: map[string]Probe{
+		"webrtc.ice": {Status: StatusUnsupported, Value: []byte(`{"reason":"no RTCPeerConnection"}`)},
+	}}
+	got := sectionWebRTC(r, Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: a browser is never read as lacking a feature", got.Determination, Unverified)
+	}
+}
+
+func TestWebRTCIsUnverifiedWhenTheGatheringStateIsMissing(t *testing.T) {
+	r := Request{Probes: map[string]Probe{
+		"webrtc.ice": {Status: StatusOK, Value: []byte(`{"timedOut":false,"sawStates":[],"candidateTypes":[]}`)},
+	}}
+	got := sectionWebRTC(r, Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: an incomplete payload settles nothing", got.Determination, Unverified)
+	}
+}
+
+func TestWebRTCIsUnverifiedWithNoCandidatesAtAll(t *testing.T) {
+	got := sectionWebRTC(webrtcRequest(t, "complete", false, []string{"gathering", "complete"}, nil), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: this reading never carries a verdict, including when a real environment produced no candidates at all", got.Determination, Unverified)
+	}
+}
+
+func TestWebRTCIsUnverifiedWithHostCandidatesReported(t *testing.T) {
+	got := sectionWebRTC(webrtcRequest(t, "complete", false, []string{"new", "gathering", "complete"}, []string{"host"}), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q", got.Determination, Unverified)
+	}
+}
+
+func TestWebRTCIsUnverifiedOnTimeout(t *testing.T) {
+	got := sectionWebRTC(webrtcRequest(t, "gathering", true, []string{"new", "gathering"}, nil), Inputs{}, claim{})
+	if got.Determination != Unverified {
+		t.Fatalf("determination = %q, want %q: gathering that never finished settles nothing", got.Determination, Unverified)
+	}
+}
+
+func TestWebRTCReportsCandidateCountsByType(t *testing.T) {
+	got := sectionWebRTC(webrtcRequest(t, "complete", false, []string{"complete"}, []string{"host", "host", "srflx"}), Inputs{}, claim{})
+	counts := map[string]string{}
+	for _, row := range got.Rows {
+		counts[row.Label] = row.Value
+	}
+	if counts["candidates of type host"] != "2" {
+		t.Errorf("host count = %q, want %q", counts["candidates of type host"], "2")
+	}
+	if counts["candidates of type srflx"] != "1" {
+		t.Errorf("srflx count = %q, want %q", counts["candidates of type srflx"], "1")
+	}
+	if counts["candidates of type relay"] != "0" {
+		t.Errorf("relay count = %q, want %q", counts["candidates of type relay"], "0")
+	}
+}
+
+func TestWebRTCNeverReachesContradictionOrInstrumented(t *testing.T) {
+	cases := []Request{
+		{Probes: map[string]Probe{}},
+		{Probes: map[string]Probe{"webrtc.ice": {Status: StatusUnsupported, Value: []byte(`{}`)}}},
+		webrtcRequest(t, "complete", false, []string{"gathering", "complete"}, nil),
+		webrtcRequest(t, "complete", false, []string{"gathering", "complete"}, []string{"host"}),
+		webrtcRequest(t, "gathering", true, []string{"new", "gathering"}, nil),
+		webrtcRequest(t, "new", false, []string{}, []string{"host", "srflx", "relay"}),
+	}
+	for i, r := range cases {
+		got := sectionWebRTC(r, Inputs{}, claim{})
+		if got.Determination == Contradiction || got.Determination == Instrumented {
+			t.Errorf("case %d: determination = %q, this reading must never reach a verdict", i, got.Determination)
+		}
+	}
+}
+
+func TestWebRTCDoesNotDiluteAPayloadThatPredatesIt(t *testing.T) {
+	sections := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Inconclusive},
+	}
+	before := summarise(sections)
+
+	absent := sectionWebRTC(Request{Probes: map[string]Probe{}}, Inputs{}, claim{})
+	absent.ID = "webrtc"
+	after := summarise(append(sections, normalise(absent)))
+
+	if before.Band != after.Band {
+		t.Errorf("band moved from %q to %q merely by adding a reading the payload has no data for", before.Band, after.Band)
+	}
+	if before.HumanConfidence != after.HumanConfidence {
+		t.Errorf("human confidence moved from %d to %d", before.HumanConfidence, after.HumanConfidence)
+	}
+	if before.BotLikeness != after.BotLikeness {
+		t.Errorf("bot likeness moved from %d to %d", before.BotLikeness, after.BotLikeness)
+	}
+}
+
+func TestWebRTCDoesNotDiluteAPayloadEvenWhenNoCandidatesWereProduced(t *testing.T) {
+	sections := []Section{
+		{ID: "a", Determination: Consistent},
+		{ID: "b", Determination: Consistent},
+		{ID: "c", Determination: Contradiction},
+	}
+	before := summarise(sections)
+
+	zeroCandidates := sectionWebRTC(webrtcRequest(t, "complete", false, []string{"gathering", "complete"}, nil), Inputs{}, claim{})
+	zeroCandidates.ID = "webrtc"
+	after := summarise(append(sections, normalise(zeroCandidates)))
+
+	if before.Band != after.Band {
+		t.Errorf("band moved from %q to %q by adding the zero-candidate reading, which must stay out of the count", before.Band, after.Band)
+	}
+	if before.HumanConfidence != after.HumanConfidence {
+		t.Errorf("human confidence moved from %d to %d", before.HumanConfidence, after.HumanConfidence)
+	}
+	if before.BotLikeness != after.BotLikeness {
+		t.Errorf("bot likeness moved from %d to %d", before.BotLikeness, after.BotLikeness)
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,30 @@ abstains. A screen or viewport reported as having no size settles nothing. And a
 payload missing any of the four numbers carries no weight either way, so adding
 this reading cannot change what an older payload scores.
 
+## Two graphics interfaces, one device
+
+A machine has one graphics device, and a browser offers two interfaces onto it.
+An environment where the older interface names a hardware device by vendor and
+model, while the newer interface grants no adapter at all, is reporting two
+different machines through two windows onto the same one.
+
+This is read as a modification rather than as a false claim, and it raises the
+score by one step rather than the step a contradiction raises it by. The reason
+is that an honest machine can reach this state: a policy may disable the newer
+interface, a driver may be excluded from it, and a device may support the older
+interface's backend without supporting the newer one's. What the reading
+establishes is that something between the two interfaces has been changed, which
+is a fact about the environment and not about the person using it.
+
+The request for a software fallback is never read. A machine with real hardware
+ordinarily has no software backend to offer, so an absent fallback is an ordinary
+answer; only the three requests that ask for a device are compared. The reading
+abstains outside a secure context, where the newer interface is gated and its
+absence says nothing; when the browser does not expose it at all; when no device
+was named for it to disagree with; and when the device named draws in software,
+because an environment already rasterising on the processor is not contradicted
+by having no hardware adapter.
+
 ## A device against its own decoders
 
 One reading is worth describing on its own, because it shows what the `Verified`

--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,36 @@ abstains. A screen or viewport reported as having no size settles nothing. And a
 payload missing any of the four numbers carries no weight either way, so adding
 this reading cannot change what an older payload scores.
 
+## Capabilities against the version claimed
+
+A browser names a version, and a version implies a set of capabilities. The
+reading compares the two, in one direction only: a capability that shipped
+*later* than the version claimed, found present, is disagreeing evidence. A
+capability the claimed version should have and does not is never read as
+anything.
+
+The asymmetry is the whole design. A capability can be missing on an honest
+machine for a dozen reasons that belong to a policy, a build or a platform
+rather than to the engine's age, so absence establishes nothing. But an engine
+that answers for something introduced after the version it claims cannot be
+explained that way. That direction is also where the common failure lies: a tool
+that keeps a newer engine and rewrites the version string leaves exactly this
+trace.
+
+The table records which major version each capability shipped in, sourced to the
+vendor's release notes. Only the rows observed on a real system of that version
+are verified; the rest are read as unverified, so the reading declines to use
+them. It also declines when no version can be parsed from what the environment
+claims, when no capability was reported, and when no verified row is later than
+the version claimed -- which is the ordinary case for an environment running the
+newest release, where there is nothing later to test it against.
+
+The checks themselves live in the collector, as code rather than as expressions
+sent from here to be evaluated. The capabilities are public knowledge, so
+choosing them here would buy nothing that the page could not have prepared for
+anyway, and a collector that evaluated strings from the server would no longer
+be a collector whose behaviour can be read from its own source.
+
 ## Readings that record without scoring
 
 Two readings here reach no verdict at all, by construction, and it is worth

--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,35 @@ the person using it, and it names no vendor, product or tool as the cause.
   IANA zone database is compiled in through `time/tzdata`, behind `ZONEINFO` and
   the host's own zone directories.
 
+## A device against its own decoders
+
+One reading is worth describing on its own, because it shows what the `Verified`
+flag is for.
+
+A graphics device names a generation, and a generation carries a documented set of
+hardware video decoders. So an environment that names a device, demonstrates a
+working hardware decoder for one codec, and reports no hardware decoder for
+another codec that its own generation carries, has stated three things that cannot
+all describe one machine. The control codec is what makes this a reading rather
+than a complaint about a missing feature: an environment with no hardware decoder
+at all is not being read as missing one decoder in particular, and abstains.
+
+The reading abstains in every other direction too. A payload that names no device,
+a device outside the table, a codec this build cannot decode by any path, a
+generation the table does not record as carrying the decoder, a reading the
+collector did not report — each of those carries no weight, and none of them
+lowers the proportion of readings that reached a determination, so adding this
+reading cannot change what an older payload scores.
+
+And it abstains on any generation whose table entry is not `Verified`. Documented
+capability is not the same as observed capability: hardware decoding of a codec can
+be unavailable on a real machine for reasons that belong to the driver or the
+platform rather than the device. So an entry becomes evidence only once the
+project has watched a real system of that configuration report the decoder, and
+the entry records which system that was. Today one generation meets that bar. The
+others are tabulated, sourced, and read as `Unverified` until someone observes
+them.
+
 ## Building and testing
 
 `make check` runs `gofmt`, `go vet` and `go test` across the module. `make fmt`,

--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,26 @@ abstains. A screen or viewport reported as having no size settles nothing. And a
 payload missing any of the four numbers carries no weight either way, so adding
 this reading cannot change what an older payload scores.
 
+## Readings that record without scoring
+
+Two readings here reach no verdict at all, by construction, and it is worth
+saying why they exist.
+
+A surface can be worth watching before this project knows what an honest browser
+does on it. Candidate gathering produces a state sequence and a set of candidate
+kinds; two serialisation paths for one drawing surface produce two byte streams.
+In both cases a difference has been observed between one environment and another,
+and in neither case has the range an unmodified browser produces across builds,
+drivers and configurations been established. A verdict drawn from that would be a
+guess wearing the clothes of evidence, which is what the verified flag on a
+reference table exists to prevent.
+
+So they collect, they show what they read, and they carry no weight in any
+direction. Their tests assert that: adding either of them moves neither the band
+nor the confidence, on every input shape they accept, including the inputs where
+the two environments differed. When someone establishes the honest range, the rows
+these readings have been recording are what the question gets settled against.
+
 ## Two graphics interfaces, one device
 
 A machine has one graphics device, and a browser offers two interfaces onto it.

--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,26 @@ the person using it, and it names no vendor, product or tool as the cause.
   IANA zone database is compiled in through `time/tzdata`, behind `ZONEINFO` and
   the host's own zone directories.
 
+## A viewport against its own screen
+
+The simplest reading in the project needs no reference table at all.
+
+A page is given an area to draw in, and it is told the size of the output device it
+is drawn on. Both are reported in CSS pixels, and both scale together: a display
+scaling factor that inflates the viewport inflates the reported screen with it. So
+a viewport larger than its own screen is not a matter of degree or of any vendor's
+behaviour. It is arithmetic.
+
+The reading declines wherever the arithmetic stops being decisive. A window
+positioned so that part of it hangs off the bottom of the screen is ordinary, and
+is not read as anything; only the drawing area itself is compared, never the window
+box or the work area, because a window may legitimately overlap a taskbar or extend
+past an edge. A window whose offset from the origin is negative sits on a display
+other than the one measured, whose size this reading was never given, so it
+abstains. A screen or viewport reported as having no size settles nothing. And a
+payload missing any of the four numbers carries no weight either way, so adding
+this reading cannot change what an older payload scores.
+
 ## A device against its own decoders
 
 One reading is worth describing on its own, because it shows what the `Verified`

--- a/reference/enginefeatures.go
+++ b/reference/enginefeatures.go
@@ -1,0 +1,93 @@
+package reference
+
+type EngineFeature struct {
+	ID string
+
+	Description string
+
+	ShipsInMajor int
+
+	Source Source
+
+	Observed string
+
+	Verified bool
+}
+
+var EngineFeatures = []EngineFeature{
+	{
+		ID:           "textFit",
+		Description:  "the text-fit CSS property",
+		ShipsInMajor: 150,
+		Source: Source{
+			Origin:  "developer.chrome.com/release-notes/150, 'text-fit scales the font size of text nodes to fit its containing box'",
+			Checked: "2026-08-27",
+		},
+		Verified: false,
+	},
+	{
+		ID:           "bgClipBorderArea",
+		Description:  "background-clip: border-area",
+		ShipsInMajor: 150,
+		Source: Source{
+			Origin:  "developer.chrome.com/release-notes/150, 'background-clip: border-area clips a background to the area painted by its border strokes'",
+			Checked: "2026-08-27",
+		},
+		Verified: false,
+	},
+	{
+		ID:           "rubyOverhang",
+		Description:  "the ruby-overhang CSS property",
+		ShipsInMajor: 151,
+		Source: Source{
+			Origin:  "developer.chrome.com/release-notes/151, 'ruby-overhang accepts auto, spaces, or none'",
+			Checked: "2026-08-27",
+		},
+		Observed: "Chrome 151.0.7922.174, Windows 10: CSS.supports('ruby-overhang','auto') answered true",
+		Verified: true,
+	},
+	{
+		ID:           "animationEventAnimation",
+		Description:  "AnimationEvent.prototype.animation",
+		ShipsInMajor: 151,
+		Source: Source{
+			Origin:  "developer.chrome.com/release-notes/151, read-only animation property added to AnimationEvent",
+			Checked: "2026-08-27",
+		},
+		Observed: "Chrome 151.0.7922.174, Windows 10: 'animation' in AnimationEvent.prototype answered true",
+		Verified: true,
+	},
+	{
+		ID:           "transitionEventAnimation",
+		Description:  "TransitionEvent.prototype.animation",
+		ShipsInMajor: 151,
+		Source: Source{
+			Origin:  "developer.chrome.com/release-notes/151, read-only animation property added to TransitionEvent",
+			Checked: "2026-08-27",
+		},
+		Observed: "Chrome 151.0.7922.174, Windows 10: 'animation' in TransitionEvent.prototype answered true",
+		Verified: true,
+	},
+	{
+		ID:           "userMediaElement",
+		Description:  "the usermedia element global constructor surface",
+		ShipsInMajor: 151,
+		Source: Source{
+			Origin:  "developer.chrome.com/release-notes/151, '<usermedia> element (MVP)'",
+			Checked: "2026-08-27",
+		},
+		Observed: "Chrome 151.0.7922.174, Windows 10: 'HTMLUserMediaElement' in window answered true",
+		Verified: true,
+	},
+	{
+		ID:           "softNavigations",
+		Description:  "the soft-navigation performance entry type",
+		ShipsInMajor: 151,
+		Source: Source{
+			Origin:  "developer.chrome.com/release-notes/151, Soft Navigations API, 'soft-navigation' and 'interaction-contentful-paint' entries",
+			Checked: "2026-08-27",
+		},
+		Observed: "Chrome 151.0.7922.174, Windows 10: PerformanceObserver.supportedEntryTypes included 'soft-navigation'",
+		Verified: true,
+	},
+}

--- a/reference/enginefeatures_test.go
+++ b/reference/enginefeatures_test.go
@@ -1,0 +1,33 @@
+package reference
+
+import "testing"
+
+func TestEngineFeaturesCarrySourceAndIDs(t *testing.T) {
+	seen := map[string]bool{}
+	for _, fe := range EngineFeatures {
+		if fe.ID == "" {
+			t.Fatalf("engine feature with empty ID: %+v", fe)
+		}
+		if seen[fe.ID] {
+			t.Fatalf("duplicate engine feature ID %q", fe.ID)
+		}
+		seen[fe.ID] = true
+		if fe.Source.Origin == "" {
+			t.Fatalf("engine feature %q has no source", fe.ID)
+		}
+		if fe.ShipsInMajor <= 0 {
+			t.Fatalf("engine feature %q has no tabulated version", fe.ID)
+		}
+		if fe.Verified && fe.Observed == "" {
+			t.Fatalf("engine feature %q is marked Verified but records no observation", fe.ID)
+		}
+	}
+}
+
+func TestEngineFeaturesOnlyMarkVerifiedWhatWasObservedOnTheExactVersionClaimed(t *testing.T) {
+	for _, fe := range EngineFeatures {
+		if fe.Verified && fe.ShipsInMajor != 151 {
+			t.Fatalf("engine feature %q is marked Verified for a tabulated version this project has not observed on a real system of that exact configuration", fe.ID)
+		}
+	}
+}

--- a/reference/gpudecode.go
+++ b/reference/gpudecode.go
@@ -1,0 +1,53 @@
+package reference
+
+type GPUDecode struct {
+	Family string
+
+	AV1Decode bool
+
+	Source Source
+
+	Observed string
+
+	Verified bool
+}
+
+var NvidiaGeForceDecode = map[string]GPUDecode{
+	"20": {
+		Family:    "Turing",
+		AV1Decode: false,
+		Source: Source{
+			Origin:  "NVIDIA Video Codec SDK, NVDEC Application Note, decode capability table (docs.nvidia.com/video-technologies/video-codec-sdk); nvidia.com/en-us/geforce/news/gfecnt/202009/rtx-30-series-av1-decoding, which announces AV1 decode as new to the 30 series",
+			Checked: "2026-08-27",
+		},
+		Verified: false,
+	},
+	"30": {
+		Family:    "Ampere",
+		AV1Decode: true,
+		Source: Source{
+			Origin:  "nvidia.com/en-us/geforce/news/gfecnt/202009/rtx-30-series-av1-decoding; NVIDIA Video Codec SDK, NVDEC Application Note, decode capability table",
+			Checked: "2026-08-27",
+		},
+		Observed: "GeForce RTX 3060 Ti (0x00002489), Windows 10 22H2, Chrome 151.0.7922.174: MediaCapabilities.decodingInfo reported powerEfficient for AV1 at 1920x1080 30fps, alongside H.264, VP9 and HEVC",
+		Verified: true,
+	},
+	"40": {
+		Family:    "Ada Lovelace",
+		AV1Decode: true,
+		Source: Source{
+			Origin:  "NVIDIA Video Codec SDK, NVDEC Application Note, decode capability table",
+			Checked: "2026-08-27",
+		},
+		Verified: false,
+	},
+	"50": {
+		Family:    "Blackwell",
+		AV1Decode: true,
+		Source: Source{
+			Origin:  "NVIDIA Video Codec SDK, NVDEC Application Note, decode capability table",
+			Checked: "2026-08-27",
+		},
+		Verified: false,
+	},
+}

--- a/reference/gpudecode_test.go
+++ b/reference/gpudecode_test.go
@@ -1,0 +1,75 @@
+package reference
+
+import "testing"
+
+func TestEveryGeForceDecodeEntryCarriesItsSource(t *testing.T) {
+	if len(NvidiaGeForceDecode) == 0 {
+		t.Fatal("the table is empty")
+	}
+	for series, entry := range NvidiaGeForceDecode {
+		if entry.Family == "" {
+			t.Errorf("series %q names no architecture", series)
+		}
+		if entry.Source.Origin == "" {
+			t.Errorf("series %q carries no source origin", series)
+		}
+		if entry.Source.Checked == "" {
+			t.Errorf("series %q carries no date it was checked", series)
+		}
+	}
+}
+
+func TestOnlyEntriesObservedOnRealHardwareAreVerified(t *testing.T) {
+	verified := []string{}
+	for series, entry := range NvidiaGeForceDecode {
+		if entry.Verified {
+			verified = append(verified, series)
+		}
+	}
+	if len(verified) == 0 {
+		t.Fatal("no entry is verified, so this table can never be read as evidence")
+	}
+	for _, series := range verified {
+		if NvidiaGeForceDecode[series].Observed == "" {
+			t.Errorf("series %q is verified but names no system it was observed on", series)
+		}
+	}
+}
+
+func TestAmpereIsTheObservedGenerationAndCarriesAV1Decode(t *testing.T) {
+	entry, ok := NvidiaGeForceDecode["30"]
+	if !ok {
+		t.Fatal("the 30 series is absent from the table")
+	}
+	if !entry.Verified {
+		t.Error("the 30 series was observed on real hardware and should be verified")
+	}
+	if !entry.AV1Decode {
+		t.Error("Ampere carries an AV1 decoder")
+	}
+}
+
+func TestTuringCarriesNoAV1DecoderAndIsNotVerified(t *testing.T) {
+	entry, ok := NvidiaGeForceDecode["20"]
+	if !ok {
+		t.Fatal("the 20 series is absent from the table")
+	}
+	if entry.AV1Decode {
+		t.Error("Turing carries no AV1 decoder")
+	}
+	if entry.Verified {
+		t.Error("the 20 series has not been observed here, so it must not be verified")
+	}
+}
+
+func TestGenerationsNotObservedHereAreNotVerified(t *testing.T) {
+	for _, series := range []string{"40", "50"} {
+		entry, ok := NvidiaGeForceDecode[series]
+		if !ok {
+			t.Fatalf("the %s series is absent from the table", series)
+		}
+		if entry.Verified {
+			t.Errorf("the %s series has not been observed here, so it must not be verified", series)
+		}
+	}
+}

--- a/web/collect.js
+++ b/web/collect.js
@@ -1558,6 +1558,45 @@ var AM = (function () {
       }
     },
     {
+      id: "engine.features",
+      group: "engine",
+      run: function () {
+        var checks = {
+          textFit: function () {
+            return CSS.supports("text-fit", "shrink");
+          },
+          bgClipBorderArea: function () {
+            return CSS.supports("background-clip", "border-area");
+          },
+          rubyOverhang: function () {
+            return CSS.supports("ruby-overhang", "auto");
+          },
+          animationEventAnimation: function () {
+            return "animation" in AnimationEvent.prototype;
+          },
+          transitionEventAnimation: function () {
+            return "animation" in TransitionEvent.prototype;
+          },
+          userMediaElement: function () {
+            return "HTMLUserMediaElement" in window;
+          },
+          softNavigations: function () {
+            return PerformanceObserver.supportedEntryTypes.indexOf("soft-navigation") >= 0;
+          }
+        };
+        var out = {};
+        var names = Object.keys(checks);
+        for (var i = 0; i < names.length; i++) {
+          var id = names[i];
+          try {
+            out[id] = Boolean(checks[id]());
+          } catch (e) {}
+        }
+        if (!Object.keys(out).length) unsupported("no capability could be evaluated in this context");
+        return out;
+      }
+    },
+    {
       id: "geom.screen",
       group: "geom",
       run: function () {

--- a/web/collect.js
+++ b/web/collect.js
@@ -1347,6 +1347,86 @@ var AM = (function () {
       }
     },
     {
+      id: "webrtc.ice",
+      group: "webrtc",
+      run: function () {
+        var Ctor = window.RTCPeerConnection || window.webkitRTCPeerConnection;
+        if (typeof Ctor !== "function") unsupported("no peer connection interface is available");
+        var pc;
+        try {
+          pc = new Ctor({ iceServers: [] });
+        } catch (e) {
+          unsupported("a peer connection could not be created: " + reasonOf(e));
+        }
+        var sawStates = [];
+        var candidateTypes = [];
+        function noteState() {
+          var st = attempt(function () {
+            return pc.iceGatheringState;
+          }, null);
+          if (st && sawStates[sawStates.length - 1] !== st) sawStates.push(st);
+        }
+        noteState();
+        var settle;
+        var finished = new Promise(function (resolve) {
+          settle = resolve;
+        });
+        pc.onicegatheringstatechange = function () {
+          noteState();
+          if (attempt(function () {
+            return pc.iceGatheringState;
+          }, null) === "complete") settle(true);
+        };
+        pc.onicecandidate = function (ev) {
+          if (!ev.candidate) {
+            noteState();
+            settle(true);
+            return;
+          }
+          var t = attempt(function () {
+            return ev.candidate.type;
+          }, null);
+          candidateTypes.push(typeof t === "string" ? t : "unknown");
+        };
+        try {
+          pc.createDataChannel("am-probe");
+        } catch (e) {}
+        var offered = Promise.resolve()
+          .then(function () {
+            return pc.createOffer();
+          })
+          .then(function (offer) {
+            return pc.setLocalDescription(offer);
+          })
+          .catch(function (e) {
+            return null;
+          });
+        return offered
+          .then(function () {
+            return withTimeout(finished, 5000, "ice gathering").then(
+              function () {
+                return false;
+              },
+              function () {
+                return true;
+              }
+            );
+          })
+          .then(function (timedOut) {
+            noteState();
+            try {
+              pc.close();
+            } catch (e) {}
+            return {
+              finalState: sawStates.length ? sawStates[sawStates.length - 1] : null,
+              timedOut: timedOut,
+              sawStates: sawStates,
+              candidateTypes: candidateTypes
+            };
+          });
+      }
+    },
+    {
       id: "geom.screen",
       group: "geom",
       run: function () {

--- a/web/collect.js
+++ b/web/collect.js
@@ -1427,6 +1427,137 @@ var AM = (function () {
       }
     },
     {
+      id: "canvas.serial",
+      group: "canvas",
+      run: function () {
+        var W = 220, H = 90;
+        var canvas = attempt(function () {
+          return document.createElement("canvas");
+        }, null);
+        if (!canvas || typeof canvas.getContext !== "function") unsupported("this document cannot create a canvas element");
+        canvas.width = W;
+        canvas.height = H;
+        var ctx = attempt(function () {
+          return canvas.getContext("2d");
+        }, null);
+        if (!ctx) unsupported("no two-dimensional drawing context was granted");
+
+        var grad = ctx.createLinearGradient(0, 0, W, H);
+        grad.addColorStop(0, "#1b3a6b");
+        grad.addColorStop(0.5, "#c8452a");
+        grad.addColorStop(1, "#e9e4d0");
+        ctx.fillStyle = grad;
+        ctx.fillRect(0, 0, W, H);
+        ctx.font = "24px serif";
+        ctx.fillStyle = "#ffffff";
+        ctx.fillText("anti-mage 0123", 8, 40);
+        ctx.strokeStyle = "rgba(0,0,0,0.55)";
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.arc(W - 30, H - 30, 20, 0, Math.PI * 1.5);
+        ctx.stroke();
+
+        function fnv1a(bytes) {
+          var h = 0x811c9dc5;
+          for (var i = 0; i < bytes.length; i++) {
+            h = h ^ bytes[i];
+            h = (h * 0x01000193) >>> 0;
+          }
+          var hex = h.toString(16);
+          while (hex.length < 8) hex = "0" + hex;
+          return hex;
+        }
+        function hashOf(buffer) {
+          return fnv1a(new Uint8Array(buffer));
+        }
+        function pixelsOf(c) {
+          return c.getContext("2d").getImageData(0, 0, W, H).data;
+        }
+        function decodeHash(src, revoke) {
+          return new Promise(function (resolve) {
+            var img = new Image();
+            img.onload = function () {
+              var out = document.createElement("canvas");
+              out.width = W;
+              out.height = H;
+              try {
+                out.getContext("2d").drawImage(img, 0, 0);
+                resolve(fnv1a(pixelsOf(out)));
+              } catch (e) {
+                resolve(null);
+              }
+              if (revoke) attempt(function () {
+                return URL.revokeObjectURL(src);
+              }, null);
+            };
+            img.onerror = function () {
+              resolve(null);
+              if (revoke) attempt(function () {
+                return URL.revokeObjectURL(src);
+              }, null);
+            };
+            img.src = src;
+          });
+        }
+
+        var out = { dataUrlAvailable: false, blobAvailable: false, rawHash: fnv1a(pixelsOf(canvas)) };
+
+        var dataUrl = attempt(function () {
+          return canvas.toDataURL("image/png");
+        }, null);
+        var dataStep = Promise.resolve();
+        if (typeof dataUrl === "string" && dataUrl.indexOf("data:image/png") === 0) {
+          out.dataUrlAvailable = true;
+          dataStep = fetch(dataUrl)
+            .then(function (r) {
+              return r.arrayBuffer();
+            })
+            .then(function (buf) {
+              out.dataUrlHash = hashOf(buf);
+              out.dataUrlLength = buf.byteLength;
+              return decodeHash(dataUrl, false);
+            })
+            .then(function (h) {
+              out.dataUrlPixelsMatchRaw = h !== null && h === out.rawHash;
+            })
+            .catch(function (e) {
+              out.dataUrlAvailable = false;
+            });
+        }
+
+        var blobStep = dataStep.then(function () {
+          if (typeof canvas.toBlob !== "function") return null;
+          return withTimeout(
+            new Promise(function (resolve) {
+              canvas.toBlob(resolve, "image/png");
+            }),
+            5000,
+            "canvas.toBlob"
+          ).catch(function (e) {
+            return null;
+          });
+        });
+
+        return blobStep
+          .then(function (blob) {
+            if (!blob || typeof blob.arrayBuffer !== "function") return null;
+            out.blobAvailable = true;
+            return blob.arrayBuffer().then(function (buf) {
+              out.blobHash = hashOf(buf);
+              out.blobLength = buf.byteLength;
+              return decodeHash(URL.createObjectURL(blob), true);
+            });
+          })
+          .then(function (h) {
+            if (out.blobAvailable) out.blobPixelsMatchRaw = h !== null && h === out.rawHash;
+            return out;
+          })
+          .catch(function (e) {
+            return out;
+          });
+      }
+    },
+    {
       id: "geom.screen",
       group: "geom",
       run: function () {

--- a/web/collect.js
+++ b/web/collect.js
@@ -1057,6 +1057,86 @@ var AM = (function () {
       }
     },
     {
+      id: "gpu.renderer",
+      group: "gpu",
+      run: function () {
+        var canvas = attempt(function () {
+          return document.createElement("canvas");
+        }, null);
+        if (!canvas || typeof canvas.getContext !== "function") {
+          unsupported("this document cannot create a canvas element");
+        }
+        var gl = attempt(function () {
+          return canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+        }, null);
+        if (!gl) unsupported("no WebGL rendering context was granted");
+        var info = attempt(function () {
+          return gl.getExtension("WEBGL_debug_renderer_info");
+        }, null);
+        var param = function (name) {
+          return attempt(function () {
+            var value = gl.getParameter(gl[name]);
+            return typeof value === "string" ? value : null;
+          }, null);
+        };
+        var unmasked = function (key) {
+          if (!info) return null;
+          return attempt(function () {
+            return gl.getParameter(info[key]);
+          }, null);
+        };
+        return {
+          vendor: param("VENDOR"),
+          renderer: param("RENDERER"),
+          version: param("VERSION"),
+          shadingLanguageVersion: param("SHADING_LANGUAGE_VERSION"),
+          unmaskedVendor: unmasked("UNMASKED_VENDOR_WEBGL"),
+          unmaskedRenderer: unmasked("UNMASKED_RENDERER_WEBGL"),
+          debugRendererInfo: !!info
+        };
+      }
+    },
+    {
+      id: "gpu.adapter",
+      group: "gpu",
+      run: function () {
+        var base = { present: !!(navigator.gpu && typeof navigator.gpu.requestAdapter === "function"), secureContext: !!isSecureContext, variants: {} };
+        if (!base.present) return base;
+        var requests = [
+          ["default", undefined],
+          ["highPerformance", { powerPreference: "high-performance" }],
+          ["lowPower", { powerPreference: "low-power" }],
+          ["fallback", { forceFallbackAdapter: true }]
+        ];
+        var chain = Promise.resolve();
+        requests.forEach(function (r) {
+          chain = chain.then(function () {
+            return withTimeout(Promise.resolve(navigator.gpu.requestAdapter(r[1])), 5000, "requestAdapter " + r[0])
+              .then(function (adapter) {
+                if (!adapter) {
+                  base.variants[r[0]] = { adapter: false };
+                  return;
+                }
+                var info = adapter.info || {};
+                base.variants[r[0]] = {
+                  adapter: true,
+                  vendor: typeof info.vendor === "string" ? info.vendor : null,
+                  architecture: typeof info.architecture === "string" ? info.architecture : null,
+                  device: typeof info.device === "string" ? info.device : null,
+                  maxTextureDimension2D: adapter.limits ? adapter.limits.maxTextureDimension2D : null
+                };
+              })
+              .catch(function (e) {
+                base.variants[r[0]] = { error: reasonOf(e) };
+              });
+          });
+        });
+        return chain.then(function () {
+          return base;
+        });
+      }
+    },
+    {
       id: "geom.screen",
       group: "geom",
       run: function () {

--- a/web/collect.js
+++ b/web/collect.js
@@ -678,6 +678,118 @@ var AM = (function () {
     });
   }
 
+  function collectNestedWorker() {
+    return new Promise(function (resolve, reject) {
+      if (typeof Worker !== "function" || typeof Blob !== "function" || !window.URL || !URL.createObjectURL) {
+        reject(Unsupported("dedicated workers or blob URLs are not available in this context"));
+        return;
+      }
+      var inner =
+        String(amFacts) +
+        ";self.onmessage=function(){try{self.postMessage({ok:true,data:amFacts('workerNested',self)});}" +
+        "catch(e){self.postMessage({ok:false,error:String(e&&e.message||e)});}};";
+      var outer =
+        "self.onmessage=function(){try{" +
+        "var u=URL.createObjectURL(new Blob([" + JSON.stringify(inner) + "],{type:'text/javascript'}));" +
+        "var w=new Worker(u);" +
+        "w.onmessage=function(ev){try{w.terminate();URL.revokeObjectURL(u);}catch(e){}self.postMessage(ev.data);};" +
+        "w.onerror=function(){try{w.terminate();URL.revokeObjectURL(u);}catch(e){}" +
+        "self.postMessage({ok:false,error:'the inner worker did not start'});};" +
+        "w.postMessage('collect');" +
+        "}catch(e){self.postMessage({ok:false,error:String(e&&e.message||e)});}};";
+      var url, w;
+      try {
+        url = URL.createObjectURL(new Blob([outer], { type: "text/javascript" }));
+        w = new Worker(url);
+      } catch (e) {
+        reject(Unsupported("the outer worker could not be created: " + reasonOf(e)));
+        return;
+      }
+      var settled = false;
+      function done(fn, arg) {
+        if (settled) return;
+        settled = true;
+        try {
+          w.terminate();
+        } catch (e) {}
+        try {
+          URL.revokeObjectURL(url);
+        } catch (e) {}
+        fn(arg);
+      }
+      w.onmessage = function (ev) {
+        if (ev.data && ev.data.ok) done(resolve, ev.data.data);
+        else done(reject, Unsupported("the nested worker reported: " + (ev.data && ev.data.error)));
+      };
+      w.onerror = function (ev) {
+        done(reject, Unsupported("the outer worker did not start: " + ((ev && ev.message) || "blocked or failed")));
+      };
+      setTimeout(function () {
+        done(reject, Unsupported("the nested worker did not answer in time"));
+      }, 4000);
+      try {
+        w.postMessage("collect");
+      } catch (e) {
+        done(reject, Unsupported("the outer worker did not accept a message: " + reasonOf(e)));
+      }
+    });
+  }
+
+  function collectFrameVariant(label, prepare) {
+    return new Promise(function (resolve, reject) {
+      var f, cleanupUrl = null;
+      try {
+        f = document.createElement("iframe");
+        f.setAttribute("title", "probe frame");
+        f.setAttribute("aria-hidden", "true");
+        f.setAttribute("tabindex", "-1");
+        f.style.cssText = "position:absolute;left:-9999px;top:-9999px;width:0;height:0;border:0";
+        cleanupUrl = prepare(f);
+        document.body.appendChild(f);
+      } catch (e) {
+        reject(Unsupported("a frame could not be created: " + reasonOf(e)));
+        return;
+      }
+      setTimeout(function () {
+        var settledValue = null;
+        var failure = null;
+        try {
+          var g = f.contentWindow;
+          if (!g || !g.navigator) failure = Unsupported("the frame's realm was not reachable");
+          else settledValue = amFacts(label, g);
+        } catch (e) {
+          failure = Unsupported("the frame's realm could not be read: " + reasonOf(e));
+        }
+        try {
+          if (f.parentNode) f.parentNode.removeChild(f);
+        } catch (e2) {}
+        try {
+          if (cleanupUrl) URL.revokeObjectURL(cleanupUrl);
+        } catch (e3) {}
+        if (failure) reject(failure);
+        else resolve(settledValue);
+      }, 80);
+    });
+  }
+
+  function collectSrcdocIframe() {
+    return collectFrameVariant("iframeSrcdoc", function (f) {
+      f.setAttribute("srcdoc", "<!doctype html><title>probe</title>");
+      return null;
+    });
+  }
+
+  function collectBlobIframe() {
+    return collectFrameVariant("iframeBlob", function (f) {
+      if (typeof Blob !== "function" || !window.URL || !URL.createObjectURL) {
+        throw Unsupported("blob URLs are not available in this context");
+      }
+      var u = URL.createObjectURL(new Blob(["<!doctype html><title>probe</title>"], { type: "text/html" }));
+      f.setAttribute("src", u);
+      return u;
+    });
+  }
+
   function collectScopes() {
     if (scopeCache) return scopeCache;
     scopeCache = Promise.all([
@@ -701,9 +813,37 @@ var AM = (function () {
         })
         .catch(function (e) {
           return { status: e && e.amUnsupported ? "unsupported" : "error", reason: reasonOf(e) };
+        }),
+      collectNestedWorker()
+        .then(function (v) {
+          return { status: "ok", value: v };
+        })
+        .catch(function (e) {
+          return { status: e && e.amUnsupported ? "unsupported" : "error", reason: reasonOf(e) };
+        }),
+      collectSrcdocIframe()
+        .then(function (v) {
+          return { status: "ok", value: v };
+        })
+        .catch(function (e) {
+          return { status: e && e.amUnsupported ? "unsupported" : "error", reason: reasonOf(e) };
+        }),
+      collectBlobIframe()
+        .then(function (v) {
+          return { status: "ok", value: v };
+        })
+        .catch(function (e) {
+          return { status: e && e.amUnsupported ? "unsupported" : "error", reason: reasonOf(e) };
         })
     ]).then(function (r) {
-      return { main: r[0], worker: r[1], iframe: r[2] };
+      return {
+        main: r[0],
+        worker: r[1],
+        iframe: r[2],
+        workerNested: r[3],
+        iframeSrcdoc: r[4],
+        iframeBlob: r[5]
+      };
     });
     return scopeCache;
   }
@@ -1037,6 +1177,27 @@ var AM = (function () {
       }
     },
     {
+      id: "scope.workerNested",
+      group: "scope",
+      run: function () {
+        return scopeSlice("workerNested");
+      }
+    },
+    {
+      id: "scope.iframeSrcdoc",
+      group: "scope",
+      run: function () {
+        return scopeSlice("iframeSrcdoc");
+      }
+    },
+    {
+      id: "scope.iframeBlob",
+      group: "scope",
+      run: function () {
+        return scopeSlice("iframeBlob");
+      }
+    },
+    {
       id: "scope.iframe",
       group: "scope",
       run: function () {
@@ -1049,7 +1210,7 @@ var AM = (function () {
       run: function () {
         return collectScopes().then(function (all) {
           var out = {};
-          ["main", "worker", "iframe"].forEach(function (k) {
+          ["main", "worker", "iframe", "workerNested", "iframeSrcdoc", "iframeBlob"].forEach(function (k) {
             out[k] = { created: all[k].status === "ok", status: all[k].status, reason: all[k].reason || null };
           });
           return out;

--- a/web/collect.js
+++ b/web/collect.js
@@ -261,6 +261,55 @@ var AM = (function () {
     if (dprDesc && typeof dprDesc.get === "function") {
       add({ key: "window.devicePixelRatio", owner: window, name: "devicePixelRatio", kind: "getter", instance: window });
     }
+    var nodeProto = proto("Node");
+    var probeDiv = attempt(function () {
+      return document.createElement("div");
+    }, null);
+    if (nodeProto && probeDiv) {
+      ["nodeType", "textContent"].forEach(function (n) {
+        add({ key: "Node.prototype." + n, owner: nodeProto, name: n, kind: "getter", instance: probeDiv });
+      });
+    }
+    var elementProto = proto("Element");
+    if (elementProto && probeDiv) {
+      add({ key: "Element.prototype.tagName", owner: elementProto, name: "tagName", kind: "getter", instance: probeDiv });
+      if (typeof elementProto.getAttribute === "function") {
+        add({
+          key: "Element.prototype.getAttribute",
+          owner: elementProto,
+          name: "getAttribute",
+          kind: "method",
+          instance: probeDiv,
+          args: ["id"]
+        });
+      }
+    }
+    var targetProto = proto("EventTarget");
+    if (targetProto && probeDiv && typeof targetProto.addEventListener === "function") {
+      add({
+        key: "EventTarget.prototype.addEventListener",
+        owner: targetProto,
+        name: "addEventListener",
+        kind: "method",
+        instance: probeDiv,
+        args: ["am-probe", null]
+      });
+    }
+    var htmlProto = proto("HTMLElement");
+    if (htmlProto && probeDiv && typeof htmlProto.click === "function") {
+      add({ key: "HTMLElement.prototype.click", owner: htmlProto, name: "click", kind: "method", instance: probeDiv, args: [] });
+    }
+    var docProto = proto("Document");
+    if (docProto && typeof docProto.createElement === "function") {
+      add({
+        key: "Document.prototype.createElement",
+        owner: docProto,
+        name: "createElement",
+        kind: "method",
+        instance: document,
+        args: ["div"]
+      });
+    }
     var elemProto = proto("Element");
     if (elemProto && typeof elemProto.getBoundingClientRect === "function") {
       add({


### PR DESCRIPTION
Collect what the graphics device says about itself, twice
Two readings that follow need to know which device an environment names and
what the newer graphics interface grants for it, and neither was being
collected. One closure reads the older interface's vendor, renderer, version
and shading language, and the unmasked pair behind the debug extension. The
other asks the newer interface for an adapter four ways unqualified, for
high performance, for low power, and for a software fallback and records what
came back for each, because a fallback that is absent on real hardware is an
ordinary answer and must not be confused with an unqualified request that
reaches nothing.